### PR TITLE
Fix startup module path

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,8 +1,8 @@
 modules = ["python-3.12", "web"]
-run = "uvicorn undefined:app --host 0.0.0.0 --port 3000"
+run = "uvicorn compliance_snapshot.app.main:app --host 0.0.0.0 --port 3000"
 
 [nix]
 channel = "stable-24_05"
 
 [deployment]
-run = ["sh", "-c", "uvicorn undefined:app --host 0.0.0.0 --port 3000"]
+run = ["sh", "-c", "uvicorn compliance_snapshot.app.main:app --host 0.0.0.0 --port 3000"]

--- a/README.md
+++ b/README.md
@@ -270,4 +270,4 @@ Copyright © 2025 [Your Company Name]. All rights reserved.
 Built with ❤️ for transportation compliance teams.
 
 # Compliance Snapshot MVP
-Run `pip install -r requirements.txt` and `uvicorn app.main:app --reload`.
+Run `pip install -r requirements.txt` and `uvicorn compliance_snapshot.app.main:app --reload`.


### PR DESCRIPTION
## Summary
- correct run command in `.replit`
- update README quick start instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685757840eec832c88e759ec65b02342