### PR TITLE
Implement async file save & PDF placeholder

### DIFF
--- a/compliance_snapshot/app/core/utils.py
+++ b/compliance_snapshot/app/core/utils.py
@@ -1,19 +1,14 @@
- codex/create-upload-form-and-routes
 from pathlib import Path
 from fastapi import UploadFile
 
-
 async def save_uploads(folder: Path, files: list[UploadFile]):
-    """Save uploaded files asynchronously to the given folder."""
-    for uploaded in files:
-        dest = folder / uploaded.filename
-        with dest.open("wb") as out_file:
+    """Save uploaded files to disk without loading into memory."""
+    for f in files:
+        dest = folder / f.filename
+        with dest.open("wb") as out:
             while True:
-                chunk = await uploaded.read(1024)
+                chunk = await f.read(1024 * 1024)  # 1 MB
                 if not chunk:
                     break
-                out_file.write(chunk)
-        await uploaded.close()
-=======
-# Utility functions
->>>>>> main
+                out.write(chunk)
+

--- a/compliance_snapshot/app/routers/upload.py
+++ b/compliance_snapshot/app/routers/upload.py
@@ -1,4 +1,3 @@
- codex/create-upload-form-and-routes
 from fastapi import APIRouter, UploadFile, File, Request, BackgroundTasks
 from fastapi.responses import HTMLResponse, FileResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
@@ -38,13 +37,4 @@ async def download(ticket: str):
     if not pdf_path.exists():
         return JSONResponse({"status": "processing"})
     return FileResponse(pdf_path, filename="ComplianceSnapshot.pdf")
-=======
-from fastapi import APIRouter
 
-router = APIRouter()
-
-@router.get("/", tags=["health"])
-async def root():
-    """Return a simple JSON to confirm the app is running."""
-    return {"status": "alive"}
->>>>>> main

--- a/compliance_snapshot/app/services/pdf_maker.py
+++ b/compliance_snapshot/app/services/pdf_maker.py
@@ -1,13 +1,11 @@
- codex/create-upload-form-and-routes
+from reportlab.platypus import SimpleDocTemplate, Paragraph
+from reportlab.lib.styles import getSampleStyleSheet
 from pathlib import Path
-from reportlab.pdfgen import canvas
 
 
 def build_placeholder_pdf(output: Path):
-    """Create a simple placeholder PDF file."""
-    c = canvas.Canvas(str(output))
-    c.drawString(100, 750, "Compliance Snapshot Placeholder")
-    c.save()
-=======
-# PDF generation utilities
->>>>> main
+    styles = getSampleStyleSheet()
+    doc = SimpleDocTemplate(str(output))
+    story = [Paragraph("Compliance Snapshot – processing placeholder", styles["Title"])]
+    doc.build(story)
+


### PR DESCRIPTION
## Summary
- refine `save_uploads` helper to stream files to disk
- stub out PDF generation with ReportLab
- clean up router implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575d0ac8c4832cae94e5837eec0945