### PR TITLE
Add HOS processor and debug print

### DIFF
--- a/compliance_snapshot/app/routers/upload.py
+++ b/compliance_snapshot/app/routers/upload.py
@@ -6,6 +6,7 @@ import uuid
 
 from ..core.utils import save_uploads
 from ..services.pdf_maker import build_placeholder_pdf  # stub for now
+from app.services.processors.hos_violations import summarize
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
@@ -25,6 +26,17 @@ async def generate(background_tasks: BackgroundTasks, files: list[UploadFile] = 
     folder.mkdir(parents=True, exist_ok=True)
 
     await save_uploads(folder, files)
+
+    # >>> BEGIN PATCH
+    # Collect any file path to test (pick the first uploaded file)
+    sample_upload_path = folder / files[0].filename
+    try:
+        hos_debug = summarize(sample_upload_path)
+        print("HOS DEBUG:", hos_debug)
+    except Exception as e:
+        # Ignore if the first file isn't a HOS sheet; just print the reason.
+        print("HOS DEBUG error:", e)
+    # >>> END PATCH
 
     output_pdf = folder / "snapshot.pdf"
     background_tasks.add_task(build_placeholder_pdf, output_pdf)

--- a/compliance_snapshot/app/services/processors/hos_violations.py
+++ b/compliance_snapshot/app/services/processors/hos_violations.py
@@ -1,0 +1,48 @@
+import pandas as pd
+from pathlib import Path
+from collections import Counter
+from openpyxl import load_workbook
+
+
+def _process_df(df: pd.DataFrame, counter: Counter) -> None:
+    """Normalise headers and update row-counts into the counter."""
+    df.columns = [c.strip().lower().replace(" ", "_") for c in df.columns]
+    if "violation_type" not in df.columns:
+        raise ValueError(
+            "Expected a 'Violation Type' column, got: "
+            + ", ".join(df.columns)
+        )
+    counter.update(df["violation_type"].value_counts().to_dict())
+
+
+def summarize(path: Path) -> dict:
+    """
+    Args:
+        path: CSV or XLSX file where each row is one violation.
+    Returns:
+        {
+          'total_violations': int,
+          'violations_by_type': {str: int}
+        }
+    """
+    counter = Counter()
+
+    if path.suffix.lower() == ".csv":
+        for chunk in pd.read_csv(path, chunksize=100_000):
+            _process_df(chunk, counter)
+    else:  # XLSX read-only streaming
+        wb = load_workbook(path, read_only=True, data_only=True)
+        ws = wb.active
+        headers = [c.value for c in next(ws.iter_rows(max_row=1))]
+        try:
+            idx = headers.index("Violation Type")
+        except ValueError as e:
+            raise ValueError("Expected 'Violation Type' header") from e
+        for row in ws.iter_rows(min_row=2, values_only=True):
+            counter[row[idx]] += 1
+
+    total = int(sum(counter.values()))
+    return {
+        "total_violations": total,
+        "violations_by_type": dict(counter)
+    }


### PR DESCRIPTION
## Summary
- implement a processor to summarize HOS violations
- print a quick debug dictionary in the `/generate` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685851dd11a8832c8038f7d3cb928908