### PR TITLE
Fix relative import in upload router

### DIFF
--- a/compliance_snapshot/app/routers/upload.py
+++ b/compliance_snapshot/app/routers/upload.py
@@ -6,7 +6,10 @@ import uuid
 
 from ..core.utils import save_uploads
 from ..services.pdf_maker import build_placeholder_pdf  # stub for now
-from app.services.processors.hos_violations import summarize
+# Import the processor using a package-relative path so uvicorn can
+# resolve the module correctly when the project is executed as
+# ``compliance_snapshot.app``.
+from ..services.processors.hos_violations import summarize
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")


### PR DESCRIPTION
## Summary
- fix hos_violations import path so uvicorn can load app package

## Testing
- `python -m uvicorn compliance_snapshot.app.main:app --help`

------
https://chatgpt.com/codex/tasks/task_e_6858546d9f3c832c8afd04b03d3e8d67