### PR TITLE
Fix uploading empty file error

### DIFF
--- a/compliance_snapshot/app/core/utils.py
+++ b/compliance_snapshot/app/core/utils.py
@@ -4,7 +4,14 @@ from fastapi import UploadFile
 async def save_uploads(folder: Path, files: list[UploadFile]):
     """Save uploaded files to disk without loading into memory."""
     for f in files:
-        dest = folder / f.filename
+        # Skip empty file inputs (browsers submit an UploadFile with an empty
+        # filename when the user leaves a file field blank).
+        if not f.filename:
+            continue
+
+        # Ensure the filename does not contain directories from the client.
+        dest = folder / Path(f.filename).name
+
         with dest.open("wb") as out:
             while True:
                 chunk = await f.read(1024 * 1024)  # 1 MB


### PR DESCRIPTION
## Summary
- ignore any files with an empty filename to avoid `IsADirectoryError`

## Testing
- `python -m compileall -q compliance_snapshot/app`

------
https://chatgpt.com/codex/tasks/task_e_685855778700832c8d9ee900d71be0ac