### PR TITLE
Fix column handling when creating charts

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -44,6 +44,7 @@ async def finalize(ticket: str,
     # 1) query full (or later: filtered) DataFrame
     con = sqlite3.connect(db_file)
     df = pd.read_sql('SELECT * FROM hos', con)
+    df.columns = [c.strip().lower().replace(' ', '_') for c in df.columns]
 
     # 2) make chart if requested
     charts_dir = Path(f"/tmp/{ticket}/charts"); charts_dir.mkdir(exist_ok=True)

--- a/compliance_snapshot/app/services/visualizations/chart_factory.py
+++ b/compliance_snapshot/app/services/visualizations/chart_factory.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 
 def make_chart(df, chart_type: str, out_path: Path):
-    counts = df["violation_type"].value_counts()
+    """Create a chart if the `violation_type` column exists."""
+    normalized = {c.strip().lower().replace(" ", "_"): c for c in df.columns}
+    if "violation_type" not in normalized:
+        return  # silently skip chart generation
+    counts = df[normalized["violation_type"]].value_counts()
     plt.figure(figsize=(6, 3))
     if chart_type == "pie":
         counts.plot.pie(autopct="%.0f%%")


### PR DESCRIPTION
## Summary
- normalize SQL query columns to snake_case
- skip chart generation when `violation_type` column missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599433cac0832cadeb08f2c9316dbf