### PR TITLE
Add table filter and better performance

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -5,9 +5,10 @@
   <!-- libs -->
   <script src="https://unpkg.com/htmx.org@1.9.10"></script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <link rel="stylesheet"
-        href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css"/>
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css"/>
+  <link rel="stylesheet" href="https://cdn.datatables.net/scroller/2.1.1/css/scroller.dataTables.min.css"/>
   <script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/scroller/2.1.1/js/dataTables.scroller.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
   <style>
@@ -61,7 +62,8 @@ async function openTab(table){
 
   // build HTML table
   const area = document.getElementById('table-area');
-  area.innerHTML = `<table id="tbl"><thead><tr>${
+  area.innerHTML = `<div id="filter"></div>
+    <table id="tbl"><thead><tr>${
       columns.map(c=>`<th>${c}</th>`).join('')
     }</tr></thead><tbody></tbody></table>
     <label style="display:block;margin:.5rem 0">
@@ -71,12 +73,26 @@ async function openTab(table){
   rows.forEach(r=>{
     tbody.insertRow().innerHTML = r.map(v=>`<td>${v}</td>`).join('');
   });
-  $('#tbl').DataTable();
+  const tbl = $('#tbl').DataTable({
+    deferRender: true,
+    scrollY: 300,
+    scroller: true
+  });
 
-  // quick bar chart by violation_type (if column exists)
+  // optional filter by violation_type
   const idx = columns.findIndex(
     c => c.toLowerCase().replace(/\s+/g, '_') === 'violation_type'
   );
+  if(idx !== -1){
+    const unique = [...new Set(rows.map(r => r[idx]))].sort();
+    const filterDiv = document.getElementById('filter');
+    const select = document.createElement('select');
+    select.innerHTML = `<option value="">All</option>` +
+      unique.map(v=>`<option value="${v}">${v}</option>`).join('');
+    select.onchange = () => tbl.column(idx).search(select.value).draw();
+    filterDiv.innerHTML = '<label>Filter violation type: </label>';
+    filterDiv.appendChild(select);
+  }
   if(idx === -1){ document.getElementById('preview').classList.add('hidden'); return; }
 
   const counts = {};


### PR DESCRIPTION
## Summary
- make DataTables load faster with the Scroller extension
- add optional dropdown filter on the `violation_type` column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685996c98a7c832c8d1e55ff1d278afb