### PR TITLE
Handle null labels in charts

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -80,7 +80,12 @@ async function openTab(table){
   if(idx === -1){ document.getElementById('preview').classList.add('hidden'); return; }
 
   const counts = {};
-  rows.forEach(r=> counts[r[idx]] = (counts[r[idx]]||0)+1);
+  rows.forEach(r=>{
+    const key = r[idx];
+    if(key !== null && key !== undefined && key !== ''){
+      counts[key] = (counts[key]||0) + 1;
+    }
+  });
   const ctx = document.getElementById('preview').getContext('2d');
   document.getElementById('preview').classList.remove('hidden');
   new Chart(ctx,{type:'bar',


### PR DESCRIPTION
## Summary
- skip null values when building chart preview counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685997521f3c832c9e8d34818ca926a2