### PR TITLE
Fix finalize download

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -73,4 +73,9 @@ async def finalize(ticket: str,
         c.drawImage(str(chart_path), 40, 460, width=520, height=250)
     c.showPage(); c.save()
 
-    return RedirectResponse(f"/download/{ticket}", status_code=303)
+    from fastapi.responses import FileResponse
+    return FileResponse(
+        path=pdf_path,
+        filename="ComplianceSnapshot.pdf",
+        media_type="application/pdf",
+    )


### PR DESCRIPTION
## Summary
- return FileResponse directly from `finalize` so the PDF downloads immediately

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685999fed118832c8e4c5b3ef25174c9