### PR TITLE
Allow showing all rows in wizard table

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -74,7 +74,7 @@ async function openTab(table){
     tbody.insertRow().innerHTML = r.map(v=>`<td>${v}</td>`).join('');
   });
   const tbl = $('#tbl').DataTable({
-    lengthMenu: [10,25,50,100],
+    lengthMenu: [[10,25,50,100,-1],[10,25,50,100,'All']],
     pageLength: 10
   });
 


### PR DESCRIPTION
## Summary
- enable DataTables "All" option so filters can apply across the entire table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599d61486c832c987cfcfca9995536