### PR TITLE
Use built‑in FileResponse filename

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -74,8 +74,9 @@ async def finalize(ticket: str,
     c.showPage(); c.save()
 
     from fastapi.responses import FileResponse
+    # use FileResponse's filename parameter to set the Content-Disposition header
     return FileResponse(
         path=pdf_path,
         media_type="application/pdf",
-        headers={"Content-Disposition": "attachment; filename=ComplianceSnapshot.pdf"},
+        filename="ComplianceSnapshot.pdf",
     )


### PR DESCRIPTION
## Summary
- send PDF using `FileResponse` filename parameter to ensure browsers download the file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68599f3d4ec0832c9941b06c7b8eef05