### PR TITLE
Add chart type selector and live chart refresh

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Request, HTTPException
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+from fastapi import Form
 from fastapi.templating import Jinja2Templates
 import sqlite3
 from pathlib import Path
@@ -45,8 +46,8 @@ async def query_table(ticket: str, table: str, limit: int | None = None):
 
 @router.post("/finalize/{ticket}")
 async def finalize(ticket: str,
-                   chart_hos: str = "on",
-                   chart_type: str = "bar"):
+                   chart_hos: str = Form("on"),
+                   chart_type: str = Form("bar")):
     db_file = _db(ticket)
     if not db_file.exists():
         raise HTTPException(404, "ticket not found")
@@ -78,10 +79,9 @@ async def finalize(ticket: str,
         c.drawImage(str(chart_path), 40, 460, width=520, height=250)
     c.showPage(); c.save()
 
-    from fastapi.responses import FileResponse
-    # use FileResponse's filename parameter to set the Content-Disposition header
     return FileResponse(
         path=pdf_path,
         media_type="application/pdf",
-        filename="ComplianceSnapshot.pdf",
+        headers={"Content-Disposition":
+                 "attachment; filename=ComplianceSnapshot.pdf"},
     )

--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -28,6 +28,17 @@
     <!-- DataTable injected here -->
     <div id="table-area"></div>
 
+    <label style="display:block;margin:.5rem 0">
+      Chart&nbsp;type:
+      <select id="chart-type">
+        <option value="bar" selected>Bar</option>
+        <option value="pie">Pie</option>
+        <option value="line">Line</option>
+      </select>
+    </label>
+    <!-- hidden field that goes to /finalize -->
+    <input type="hidden" name="chart_type" id="chart-type-hidden" value="bar">
+
     <!-- Chart preview -->
     <canvas id="preview" class="hidden"></canvas>
 
@@ -56,6 +67,7 @@ loadTabs();
 async function openTab(table){
   const res = await fetch(`/api/${ticket}/query?table=${table}`);
   const {columns, rows} = await res.json();
+  window.tableName = table;  // remember current table
 
   // build HTML table
   const area = document.getElementById('table-area');
@@ -75,6 +87,13 @@ async function openTab(table){
     pageLength: 10
   });
 
+  // When any table filter/search/paging happens, redraw the chart
+  $('#tbl').on('draw.dt', () => {
+      const table = $('#tbl').DataTable();
+      const rows  = table.rows({search:'applied'}).data().toArray();
+      drawChart(tableName, rows, columns);
+  });
+
   // build column filters
   const filtersDiv = document.getElementById('filters');
   filtersDiv.innerHTML = '';
@@ -89,24 +108,41 @@ async function openTab(table){
     filtersDiv.appendChild(select);
   });
 
-  const idx = columns.findIndex(
+  drawChart(table, rows, columns);
+}
+
+function drawChart(name, rows, cols){
+  const canvas = document.getElementById('preview');
+  if(!rows.length){ canvas.classList.add('hidden'); return; }
+
+  const idx = cols.findIndex(
     c => c.toLowerCase().replace(/\s+/g, '_') === 'violation_type'
   );
-  if(idx === -1){ document.getElementById('preview').classList.add('hidden'); return; }
+  if(idx === -1){ canvas.classList.add('hidden'); return; }
 
   const counts = {};
-  rows.forEach(r=>{
-    const key = r[idx];
-    if(key !== null && key !== undefined && key !== ''){
-      counts[key] = (counts[key]||0) + 1;
-    }
-  });
-  const ctx = document.getElementById('preview').getContext('2d');
-  document.getElementById('preview').classList.remove('hidden');
-  new Chart(ctx,{type:'bar',
+  rows.forEach(r=> counts[r[idx]] = (counts[r[idx]]||0)+1);
+
+  const ctx = canvas.getContext('2d');
+  canvas.classList.remove('hidden');
+  const chosen = document.getElementById('chart-type').value;
+  document.getElementById('chart-type-hidden').value = chosen;  // sync for form
+
+  // wipe previous chart instance if any
+  if(window.currentChart){ window.currentChart.destroy(); }
+
+  window.currentChart = new Chart(ctx,{type:chosen,
     data:{labels:Object.keys(counts),
           datasets:[{label:'count',data:Object.values(counts)}]},
-    options:{plugins:{title:{display:true,text:table}}}});
+    options:{plugins:{title:{display:true,text:name}}}});
 }
+
+// dropdown → redraw chart with new type
+document.getElementById('chart-type').addEventListener('change', ()=>{
+    const table = $('#tbl').DataTable();
+    const rows  = table.rows({search:'applied'}).data().toArray();
+    const cols  = table.columns().header().toArray().map(th=>th.innerText);
+    drawChart('hos', rows, cols);
+});
 </script>
 </body></html>


### PR DESCRIPTION
## Summary
- add a dropdown to choose bar/pie/line chart types on the wizard page
- keep chart in sync with table filters and dropdown changes
- update finalize endpoint to read form inputs for chart options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859a335d9b4832cba6fb860c0ef4f3a