### PR TITLE
Add narrative summary and dual charts

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -5,7 +5,10 @@ from fastapi.templating import Jinja2Templates
 import sqlite3
 from pathlib import Path
 import pandas as pd
-from ..services.visualizations.chart_factory import make_chart
+from ..services.visualizations.chart_factory import (
+    make_stacked_bar,
+    make_trend_line,
+)
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
@@ -52,33 +55,69 @@ async def finalize(ticket: str,
     if not db_file.exists():
         raise HTTPException(404, "ticket not found")
 
-    # 1) query full (or later: filtered) DataFrame
+    # Load full HOS DataFrame
     con = sqlite3.connect(db_file)
     df = pd.read_sql('SELECT * FROM hos', con)
-    df.columns = [c.strip().lower().replace(' ', '_') for c in df.columns]
 
-    # 2) make chart if requested
-    charts_dir = Path(f"/tmp/{ticket}/charts"); charts_dir.mkdir(exist_ok=True)
-    chart_path = charts_dir / "hos.png"
-    if chart_hos == "on":
-        make_chart(
-            df,
-            chart_type,
-            chart_path,
-            title="HOS Violations by Type",
-        )
+    # Prepare chart files
+    charts_dir = Path(f"/tmp/{ticket}/charts")
+    charts_dir.mkdir(exist_ok=True)
+    stacked_path = charts_dir / "hos_stacked.png"
+    trend_path = charts_dir / "hos_trend.png"
 
-    # 3) build simple PDF
+    # Generate charts
+    make_stacked_bar(df, stacked_path)
+    make_trend_line(df, trend_path)
+
+    # Build PDF: Page 1 with both charts
     pdf_path = Path(f"/tmp/{ticket}/ComplianceSnapshot.pdf")
     c = canvas.Canvas(str(pdf_path), pagesize=letter)
     c.setFont("Helvetica-Bold", 16)
-    c.drawString(40, 750, "Compliance Snapshot \u2013 HOS")
-    c.setFont("Helvetica", 11)
-    c.drawString(40, 730, f"Total violations: {len(df)}")
-    if chart_path.exists():
-        c.drawImage(str(chart_path), 40, 460, width=520, height=250)
-    c.showPage(); c.save()
+    c.drawString(40, 770, "Compliance Snapshot \u2013 HOS")
+    c.setFont("Helvetica", 10)
+    total = len(df)
+    c.drawString(40, 755, f"Total Violations: {total}")
+    c.drawImage(str(stacked_path), 40, 450, width=260, height=180)
+    c.drawImage(str(trend_path), 300, 450, width=260, height=180)
+    c.showPage()
 
+    # Page 2: narrative summary
+    # Compute region breakdown
+    region_counts = df.groupby('Tags').size().to_dict()
+    gl = region_counts.get('Great Lakes', 0)
+    ov = region_counts.get('Ohio Valley', 0)
+    se = region_counts.get('Southeast', 0)
+
+    # Compute week-over-week trend
+    last_two = df.copy()
+    last_two['week'] = pd.to_datetime(last_two['WEEK OF...'])
+    wo2 = last_two.groupby('week').size().sort_index()
+    prev, curr = wo2.iloc[-2], wo2.iloc[-1]
+    trend = (
+        "increased" if curr > prev else "decreased" if curr < prev else "remained flat"
+    )
+
+    narrative = (
+        f"Total violations: {total} (+{total - prev}).\n"
+        f"Violations by Region:\n"
+        f"  \u2022 Great Lakes: {gl}\n"
+        f"  \u2022 Ohio Valley: {ov}\n"
+        f"  \u2022 Southeast: {se}\n"
+        f"Week-over-Week Trend: {trend} "
+        f"({prev} \u2192 {curr})."
+    )
+
+    c.setFont("Helvetica-Bold", 14)
+    c.drawString(40, 750, "HOS Violations Summary")
+    c.setFont("Helvetica", 10)
+    text = c.beginText(40, 730)
+    for line in narrative.split('\n'):
+        text.textLine(line)
+    c.drawText(text)
+    c.showPage()
+    c.save()
+
+    # Return PDF as attachment
     return FileResponse(
         path=pdf_path,
         media_type="application/pdf",

--- a/compliance_snapshot/app/services/visualizations/chart_factory.py
+++ b/compliance_snapshot/app/services/visualizations/chart_factory.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 from pathlib import Path
+import pandas as pd
 
 
 def make_chart(df, chart_type: str, out_path: Path, title: str | None = None) -> None:
@@ -46,4 +47,41 @@ def make_chart(df, chart_type: str, out_path: Path, title: str | None = None) ->
 
     plt.tight_layout()
     plt.savefig(out_path, dpi=200)
+    plt.close()
+
+
+def make_stacked_bar(df, out_path: Path):
+    """Create stacked bar chart of violation counts per region."""
+    pivot = df.pivot_table(
+        index="Tags",
+        columns="Violation Type",
+        aggfunc="size",
+        fill_value=0,
+    )
+    ax = pivot.plot.bar(stacked=True, figsize=(6, 3))
+    ax.set_xlabel("")
+    ax.set_ylabel("Count")
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=160)
+    plt.close()
+
+
+def make_trend_line(df, out_path: Path):
+    """Create line chart of weekly violation counts."""
+    df2 = df.copy()
+    df2["week"] = pd.to_datetime(df2["WEEK OF..."])
+    pivot = (
+        df2.pivot_table(
+            index="week",
+            columns="Violation Type",
+            aggfunc="size",
+            fill_value=0,
+        )
+        .sort_index()
+    )
+    ax = pivot.plot.line(marker="o", figsize=(6, 3))
+    ax.set_xlabel("")
+    ax.set_ylabel("Count")
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=160)
     plt.close()


### PR DESCRIPTION
## Summary
- generate stacked bar and trend line charts
- produce a two-page PDF with charts and narrative summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a81fbec0832c94ae125295736809