### PR TITLE
Add trend end date control

### DIFF
--- a/compliance_snapshot/app/services/visualizations/chart_factory.py
+++ b/compliance_snapshot/app/services/visualizations/chart_factory.py
@@ -47,3 +47,19 @@ def make_chart(df, chart_type: str, out_path: Path, title: str | None = None) ->
     plt.tight_layout()
     plt.savefig(out_path, dpi=200)
     plt.close()
+
+
+def make_trend_line(df, out_path: Path, title: str | None = None) -> None:
+    """Create a simple line chart showing counts per week."""
+    plt.style.use("seaborn-v0_8-whitegrid")
+    counts = df.groupby("week").size().sort_index()
+
+    plt.figure(figsize=(7, 4))
+    counts.plot.line(marker="o")
+    plt.xlabel("Week")
+    plt.ylabel("Count")
+    if title:
+        plt.title(title)
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=200)
+    plt.close()

--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -23,8 +23,11 @@
   <!-- Tabs will be built by JS -->
   <nav id="tabs"></nav>
 
-  <!-- Finalize form (standard submit for file download) -->
-  <form id="finalize" action="/finalize/{{ ticket }}" method="post">
+  <!-- Finalize form (HTMX submit for PDF download) -->
+  <form id="finalize"
+        hx-post="/finalize/{{ ticket }}"
+        hx-include="input"
+        hx-target="body" hx-swap="innerHTML">
     <!-- DataTable injected here -->
     <div id="table-area"></div>
 
@@ -41,6 +44,12 @@
 
     <!-- Chart preview -->
     <canvas id="preview" class="hidden"></canvas>
+
+    <label style="display:block;margin:1rem 0">
+      Trend&nbsp;end&nbsp;date:
+      <input type="date" name="trend_end" id="trend-end">
+      <small>(defaults to latest week if left blank)</small>
+    </label>
 
     <button type="submit">Build PDF</button>
   </form>


### PR DESCRIPTION
## Summary
- add HTMX finalize form with trend end date picker
- include manual trend chart generation in finalize endpoint
- add helper to create weekly trend line charts

## Testing
- `python -m py_compile compliance_snapshot/app/routers/wizard.py compliance_snapshot/app/services/visualizations/chart_factory.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a51bed84832c9f69de6946497abe