### PR TITLE
Fix trend line generation

### DIFF
--- a/compliance_snapshot/app/services/visualizations/chart_factory.py
+++ b/compliance_snapshot/app/services/visualizations/chart_factory.py
@@ -56,20 +56,51 @@ def make_stacked_bar(df: pd.DataFrame, out_path: Path) -> None:
 
 
 def make_trend_line(df: pd.DataFrame, out_path: Path) -> None:
-    """Create a line chart of weekly violation counts."""
+    """Create a line chart of weekly violation counts.
+
+    The function is resilient to variations in the week column name and
+    will plot one line per ``Violation Type`` or, if that column is not
+    available, one line for each numeric column in ``df``.
+    """
+
     plt.style.use("seaborn-v0_8-whitegrid")
+
     df2 = df.copy()
-    df2["week"] = pd.to_datetime(df2["WEEK OF..."])
-    pivot = (
-        df2.pivot_table(
-            index="week",
-            columns="Violation Type",
-            aggfunc="size",
-            fill_value=0,
-        )
-        .sort_index()
+
+    # Detect the column containing week information
+    normalized = {c.lower().replace(" ", "_").replace(".", ""): c for c in df2.columns}
+    week_col = normalized.get("week") or next(
+        (c for k, c in normalized.items() if k.startswith("week")),
+        None,
     )
-    ax = pivot.plot.line(marker="o", figsize=(7, 4))
+    if not week_col:
+        return  # Cannot build trend line without week information
+
+    if week_col != "week":
+        df2["week"] = pd.to_datetime(df2[week_col])
+    else:
+        df2["week"] = pd.to_datetime(df2["week"])
+
+    # Determine which columns to plot. Prefer ``Violation Type`` if present.
+    vt_col = normalized.get("violation_type")
+    if vt_col:
+        pivot = (
+            df2.pivot_table(
+                index="week",
+                columns=vt_col,
+                aggfunc="size",
+                fill_value=0,
+            )
+            .sort_index()
+        )
+    else:
+        numeric_cols = [c for c in df2.columns if c != "week" and pd.api.types.is_numeric_dtype(df2[c])]
+        if not numeric_cols:
+            return
+        pivot = df2.set_index("week")[numeric_cols]
+
+    colors = plt.cm.tab10.colors
+    ax = pivot.plot.line(marker="o", figsize=(7, 4), color=colors[: len(pivot.columns)])
     ax.set_xlabel("")
     ax.set_ylabel("Count")
     plt.tight_layout()


### PR DESCRIPTION
## Summary
- handle various week column names when plotting trends
- gracefully fallback if week or violation columns missing
- plot all series with distinct colors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aecdfd18832c82fe375f59814b35