### PR TITLE
Adjust stacked bar chart and bold headings

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -161,9 +161,16 @@ async def finalize(ticket: str,
 
     c.setFont("Helvetica-Bold", 14)
     c.drawString(40, 750, "HOS Violations Summary")
-    c.setFont("Helvetica", 10)
     text = c.beginText(40, 730)
     for line in narrative.split("\n"):
+        if line.strip() in {
+            "\u2022 Violations by Region:",
+            "\u2022 HOS Violations Week-over-Week Comparison:",
+            "\u2022 Top Violation Types:",
+        }:
+            text.setFont("Helvetica-Bold", 10)
+        else:
+            text.setFont("Helvetica", 10)
         text.textLine(line)
     c.drawText(text)
     c.showPage()

--- a/compliance_snapshot/app/services/visualizations/chart_factory.py
+++ b/compliance_snapshot/app/services/visualizations/chart_factory.py
@@ -49,22 +49,25 @@ def make_chart(df, chart_type: str, out_path: Path, title: str | None = None) ->
 
 def make_stacked_bar(df: pd.DataFrame, out_path: Path) -> None:
     """Create a stacked bar chart of violation counts per region."""
+
     plt.style.use("seaborn-v0_8-whitegrid")
     df = _drop_null_rows(df, ["Tags", "Violation Type"])
     pivot = (
         df.pivot_table(
-            index="Tags",
-            columns="Violation Type",
+            index="Tags",            # x-axis labels (e.g. GL, OV, SE)
+            columns="Violation Type", # stacked bars by violation type
             aggfunc="size",
             fill_value=0,
         )
         .sort_index(axis=1)
     )
-    ax = pivot.plot.bar(stacked=True, figsize=(7, 4))
+
+    ax = pivot.plot.bar(stacked=True, figsize=(6, 3))
+    plt.xticks(rotation=0)  # keep region labels horizontal
     ax.set_xlabel("")
     ax.set_ylabel("Count")
     plt.tight_layout()
-    plt.savefig(out_path, dpi=200)
+    plt.savefig(out_path, dpi=160)
     plt.close()
 
 


### PR DESCRIPTION
## Summary
- tweak stacked bar pivot and formatting
- emphasize key headings in the generated PDF

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b87212fc832cbf4ef4ba05deea00