### PR TITLE
Fix column detection for chart preview

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -116,7 +116,13 @@ function drawChart(name, rows, cols){
   const canvas = document.getElementById('preview');
   if(!rows.length){ canvas.classList.add('hidden'); return; }
 
-  const idx = cols.findIndex(c => c.toLowerCase().replace(/\s+/g,'_') === 'violation_type');
+  // Find the Violation Type column regardless of casing, spaces, or invisible
+  // sort icons that DataTables adds to the header text.
+  const normalize = s => s.toLowerCase()
+                           .replace(/[^a-z\s]/g, '')   // strip non-letters
+                           .replace(/\s+/g, '_')        // spaces → underscore
+                           .trim();
+  const idx = cols.findIndex(c => normalize(c) === 'violation_type');
   if(idx === -1){ canvas.classList.add('hidden'); return; }
 
   const counts = {};


### PR DESCRIPTION
## Summary
- improve `wizard.html` chart column detection by ignoring DataTables sort icons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b96a1634832c9a4d435b25c41dd4