### PR TITLE
Add multi-line violation trend graph

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -5,7 +5,7 @@ from fastapi.templating import Jinja2Templates
 import sqlite3
 from pathlib import Path
 import pandas as pd
-from ..services.visualizations.chart_factory import make_chart
+from ..services.visualizations.chart_factory import make_chart, make_trend_line
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
@@ -66,7 +66,10 @@ async def finalize(ticket: str,
     charts_dir.mkdir(exist_ok=True)
     chart_path = charts_dir / "hos_chart.png"
 
-    make_chart(df, chart_type, chart_path, title="Violations by Type")
+    if chart_type == "line":
+        make_trend_line(df, chart_path)
+    else:
+        make_chart(df, chart_type, chart_path, title="Violations by Type")
 
     pdf_path = Path(f"/tmp/{ticket}/ComplianceSnapshot.pdf")
     c = canvas.Canvas(str(pdf_path), pagesize=letter)

--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -116,16 +116,10 @@ function drawChart(name, rows, cols){
   const canvas = document.getElementById('preview');
   if(!rows.length){ canvas.classList.add('hidden'); return; }
 
-  const idx = cols.findIndex(c => c.toLowerCase().replace(/\s+/g,'_') === 'violation_type');
-  if(idx === -1){ canvas.classList.add('hidden'); return; }
+  const vtIdx = cols.findIndex(c => c.toLowerCase().replace(/\s+/g,'_') === 'violation_type');
+  if(vtIdx === -1){ canvas.classList.add('hidden'); return; }
 
-  const counts = {};
-  rows.forEach(r => {
-    const val = r[idx];
-    if(val !== null && val !== undefined && String(val).trim().toLowerCase() !== 'null'){
-      counts[val] = (counts[val] || 0) + 1;
-    }
-  });
+  const weekIdx = cols.findIndex(c => c.toLowerCase().replace(/\s+/g,'_') === 'week');
 
   const ctx = canvas.getContext('2d');
   const chosen = document.getElementById('chart-type').value;
@@ -134,11 +128,46 @@ function drawChart(name, rows, cols){
   if(window.currentChart){ window.currentChart.destroy(); }
 
   canvas.classList.remove('hidden');
-  window.currentChart = new Chart(ctx,{
-    type: chosen,
-    data:{ labels: Object.keys(counts), datasets:[{label:'count',data:Object.values(counts)}] },
-    options:{plugins:{title:{display:true,text:name}}}
-  });
+
+  if(chosen === 'line' && weekIdx !== -1){
+    const counts = {};
+    const weeks = new Set();
+    rows.forEach(r => {
+      const vt = r[vtIdx];
+      const wk = r[weekIdx];
+      if(vt && wk){
+        counts[vt] = counts[vt] || {};
+        counts[vt][wk] = (counts[vt][wk] || 0) + 1;
+        weeks.add(wk);
+      }
+    });
+    const weekLabels = Array.from(weeks).sort();
+    const palette = ['#3366CC','#DC3912','#FF9900','#109618','#990099','#0099C6','#DD4477','#66AA00','#B82E2E','#316395'];
+    const datasets = Object.entries(counts).map(([type, byWeek], i) => ({
+      label: type,
+      data: weekLabels.map(w => byWeek[w] || 0),
+      borderColor: palette[i % palette.length],
+      fill: false
+    }));
+    window.currentChart = new Chart(ctx,{
+      type: 'line',
+      data:{ labels: weekLabels, datasets },
+      options:{plugins:{title:{display:true,text:name}}}
+    });
+  }else{
+    const counts = {};
+    rows.forEach(r => {
+      const val = r[vtIdx];
+      if(val !== null && val !== undefined && String(val).trim().toLowerCase() !== 'null'){
+        counts[val] = (counts[val] || 0) + 1;
+      }
+    });
+    window.currentChart = new Chart(ctx,{
+      type: chosen,
+      data:{ labels: Object.keys(counts), datasets:[{label:'count',data:Object.values(counts)}] },
+      options:{plugins:{title:{display:true,text:name}}}
+    });
+  }
 }
 
 // dropdown → redraw chart with new type


### PR DESCRIPTION
## Summary
- update wizard page JS to render multi-line trend charts for violation types
- generate trend chart in PDF when line graph is selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b9c9ce0c832c99e546d2ef62829b