### PR TITLE
Restore manual trend-end date picker

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -51,6 +51,11 @@
 
     <input type="hidden" name="filter_search" id="filter-search-hidden" value="">
 
+    <label style="display:block;margin:1rem 0">
+      Trend&nbsp;end&nbsp;date:
+      <input type="date" name="trend_end" id="trend-end">
+      <small>(defaults to latest week if left blank)</small>
+    </label>
 
     <button type="submit">Build PDF</button>
   </form>


### PR DESCRIPTION
## Summary
- add a trend end date input in the wizard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859fa6ff498832cb79080273825c468