### PR TITLE
Fix PDF download action

### DIFF
--- a/compliance_snapshot/app/routers/upload.py
+++ b/compliance_snapshot/app/routers/upload.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, UploadFile, File, Request, BackgroundTasks
-from fastapi.responses import HTMLResponse, FileResponse, JSONResponse
+from fastapi.responses import HTMLResponse, FileResponse, JSONResponse, HTTPException
 from fastapi.templating import Jinja2Templates
 from pathlib import Path
 import uuid
@@ -44,8 +44,15 @@ async def generate(background_tasks: BackgroundTasks, files: list[UploadFile] = 
 
 @router.get("/download/{ticket}", tags=["generate"])
 async def download(ticket: str):
-    pdf_path = Path(f"/tmp/{ticket}/snapshot.pdf")
+    """Return the generated PDF as a downloadable file."""
+    pdf_path = Path(f"/tmp/{ticket}/ComplianceSnapshot.pdf")
     if not pdf_path.exists():
-        return JSONResponse({"status": "processing"})
-    return FileResponse(pdf_path, filename="ComplianceSnapshot.pdf")
+        raise HTTPException(status_code=404, detail="snapshot not found")
+
+    # FastAPI adds 'attachment' disposition when filename is provided
+    return FileResponse(
+        path=pdf_path,
+        media_type="application/pdf",
+        filename=f"DOT_Compliance_{ticket[:8]}.pdf",
+    )
 

--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Request, HTTPException
-from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi import Form
 from fastapi.templating import Jinja2Templates
 import sqlite3
@@ -179,8 +179,5 @@ async def finalize(ticket: str,
     c.showPage()
     c.save()
 
-    return FileResponse(
-        path=pdf_path,
-        media_type="application/pdf",
-        headers={"Content-Disposition": "attachment; filename=ComplianceSnapshot.pdf"},
-    )
+    # PDF is now ready for download via /download
+    return JSONResponse({"status": "ok"})

--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -24,10 +24,7 @@
   <nav id="tabs"></nav>
 
   <!-- Finalize form: generates PDF on submit -->
-  <form id="finalize"
-        hx-post="/finalize/{{ ticket }}"
-        hx-include="input"
-        hx-target="body" hx-swap="innerHTML">
+  <form id="finalize" data-ticket="{{ ticket }}">
     <!-- DataTable injected here -->
     <div id="table-area"></div>
 
@@ -212,6 +209,6 @@ function drawChart(name, rows, cols){
   }
 }
 
-/* old per-change hook removed; combined into updatePreview */
 </script>
+<script src="/static/js/wizard.js"></script>
 </body></html>

--- a/static/js/wizard.js
+++ b/static/js/wizard.js
@@ -1,0 +1,18 @@
+const form = document.getElementById('finalize');
+if (form) {
+  form.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const data = new FormData(form);
+    const wizId = window.ticket || form.dataset.ticket;
+    await fetch(`/finalize/${wizId}`, {
+      method: 'POST',
+      body: data
+    });
+    const link = document.createElement('a');
+    link.href = `/download/${wizId}`;
+    link.download = '';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  });
+}


### PR DESCRIPTION
## Summary
- make /download/<ticket> always return a downloadable PDF
- finalize wizard step via AJAX and trigger download with JS
- expose new wizard.js script and remove HTMX attributes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae5664d68832c9066faf32db01c81