### PR TITLE
Add reactive table filtering and chart sync JS

### DIFF
--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -1,0 +1,8 @@
+let dataset = rows;
+renderCharts(dataset);
+
+// when table filters change, redraw with the *filtered* subset
+document.addEventListener("tableFiltered", e => {
+  dataset = e.detail;
+  renderCharts(dataset);
+});

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -1,0 +1,40 @@
+// rows = array of plain JS objects already fetched
+const rows = await (await fetch(`/api/${wizId}/query?table=hos`)).json();
+let activeFilters = {};               // { colName -> value }
+renderTable(rows);
+
+/* ---------- column-header filters ---------- */
+// assume each th has data-col="<field>" & a <input> or <select>
+document.querySelectorAll("th .filter").forEach(ctrl => {
+  ctrl.addEventListener("input", e => {
+    const col = e.target.closest("th").dataset.col;
+    const val = e.target.value.trim();
+    if (val) activeFilters[col] = val.toLowerCase();
+    else     delete activeFilters[col];           // cleared ⇒ remove filter
+
+    // 1️⃣  recompute visible rows
+    const visible = rows.filter(r =>
+      Object.entries(activeFilters).every(([c,v]) =>
+        String(r[c] ?? "").toLowerCase().includes(v)
+      )
+    );
+
+    // 2️⃣  redraw table *and* notify charts
+    renderTable(visible);
+    document.dispatchEvent(new CustomEvent("tableFiltered", { detail: visible }));
+  });
+});
+
+function renderTable(data) {
+  const tbody = document.querySelector("#hos-tbody");
+  tbody.innerHTML = data.map(r => `
+    <tr>
+      <td>${r.date}</td>
+      <td>${r.driver}</td>
+      <td>${r["Violation Type"]}</td>
+      <td>${r.tags}</td>
+      <td>${r.region}</td>
+      <td>${r.duration}</td>
+    </tr>`).join("");
+  document.querySelector("#row-count").textContent = data.length;
+}


### PR DESCRIPTION
## Summary
- add vanilla JS table filtering logic
- add chart update listener for filtered tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae5c5d98c832ca34321c564998692