### PR TITLE
Fix HTTPException import

### DIFF
--- a/compliance_snapshot/app/routers/upload.py
+++ b/compliance_snapshot/app/routers/upload.py
@@ -1,5 +1,5 @@
-from fastapi import APIRouter, UploadFile, File, Request, BackgroundTasks
-from fastapi.responses import HTMLResponse, FileResponse, JSONResponse, HTTPException
+from fastapi import APIRouter, UploadFile, File, Request, BackgroundTasks, HTTPException
+from fastapi.responses import HTMLResponse, FileResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from pathlib import Path
 import uuid


### PR DESCRIPTION
## Summary
- fix HTTPException import path in `upload` router

## Testing
- `pip install -q -r requirements.txt`
- `python -m compileall -q compliance_snapshot/app`
- `python - <<'PY'
import compliance_snapshot.app.main as m
print('app title:', m.app.title)
PY`

------
https://chatgpt.com/codex/tasks/task_e_685ae7171b3c832c89901b36ad402feb