### PR TITLE
Fix missing Request import

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
 from fastapi.templating import Jinja2Templates
 import sqlite3


### PR DESCRIPTION
## Summary
- resolve NameError for Request in wizard router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aec9b3cf0832c9381c1b5ef52eeba