### PR TITLE
Add chart toggle and filter support

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -39,10 +39,10 @@
     <!-- hidden field that goes to /finalize -->
     <input type="hidden" name="chart_type" id="chart-type-hidden" value="bar">
 
-    <!-- Toggle whether to include the chart -->
+    <!-- Toggle whether to include charts in the final PDF -->
     <label style="margin-top:.5rem;display:block">
-       <input type="checkbox" id="include-chart" checked>
-       include chart
+       <input type="checkbox" id="include-charts" checked>
+       include charts
     </label>
 
     <!-- Chart preview -->
@@ -83,6 +83,9 @@ async function openTab(table){
   const {columns, rows} = await res.json();
   window.tableName = table;  // remember current table
 
+  window.activeFilters = window.activeFilters || {};
+  const filters = window.activeFilters;
+
   // build HTML table
   const area = document.getElementById('table-area');
   area.innerHTML = `<div id="filters" style="margin-bottom:.5rem"></div>
@@ -102,7 +105,7 @@ async function openTab(table){
   function updatePreview(){
       const table     = $('#tbl').DataTable();
       const searchStr = table.search();
-      const include   = document.getElementById('include-chart').checked;
+      const include   = document.getElementById('include-charts').checked;
 
       // propagate hidden fields for /finalize
       $('#filter-search-hidden').val(include ? searchStr : "");
@@ -122,7 +125,7 @@ async function openTab(table){
   $('#tbl').on('draw.dt', updatePreview);       // fires after search OR pagination
   document.getElementById('chart-type')
           .addEventListener('change', updatePreview);
-  document.getElementById('include-chart')
+  document.getElementById('include-charts')
           .addEventListener('change', updatePreview);
 
   // initial render
@@ -138,7 +141,11 @@ async function openTab(table){
     const select = document.createElement('select');
     select.innerHTML = `<option value="">${col}</option>` +
       unique.map(v => `<option value="${v}">${v}</option>`).join('');
-    select.onchange = () => tbl.column(i).search(select.value).draw();
+    select.onchange = () => {
+      if(select.value) filters[col] = select.value;
+      else delete filters[col];
+      dt.column(i).search(select.value).draw();
+    };
     filtersDiv.appendChild(select);
   });
 

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -7,7 +7,7 @@ export async function buildTable(selector, columns) {
   // Build the header cells
   headerRow.innerHTML = columns.map(c => `<th>${c}</th>`).join("");
 
-  const filters = {};                // {col: value}
+  const filters = window.activeFilters || (window.activeFilters = {}); // {col: value}
 
   // initial fetch + render
   let df = await fetchData(filters);

--- a/static/js/wizard.js
+++ b/static/js/wizard.js
@@ -1,10 +1,28 @@
-const form = document.querySelector('#finalize-form');
-if (form) {
-  form.addEventListener('submit', async (e) => {
+const wizId   = location.pathname.split('/').pop();
+const buildBtn = document.getElementById('build-pdf');
+const incChk   = document.getElementById('include-charts');
+
+// global object updated by table.js
+window.activeFilters = window.activeFilters || {};
+
+if (buildBtn) {
+  buildBtn.addEventListener('click', async (e) => {
     e.preventDefault();
-    const data = new FormData(e.target);
-    const wizId = window.ticket || form.dataset.ticket;
-    const res = await fetch(`/finalize/${wizId}`, { method: 'POST', body: data });
-    window.location = res.headers.get('Location');      // triggers download
+    const payload = {
+      filters: window.activeFilters,
+      include_charts: incChk ? incChk.checked : true,
+    };
+    await fetch(`/finalize/${wizId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    const res = await fetch(`/download/${wizId}`);
+    const blob = await res.blob();
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'DOT_Compliance_Snapshot.pdf';
+    a.click();
   });
 }


### PR DESCRIPTION
## Summary
- add checkbox to include charts in PDF
- send filters and chart flag during PDF build
- allow wizard tables to track filters globally
- update PDF builder to apply filters and optional charts
- return redirect from finalize endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685af2164330832ca31a963b46c1a4eb