### PR TITLE
Fix PDF download

### DIFF
--- a/static/js/wizard.js
+++ b/static/js/wizard.js
@@ -12,13 +12,15 @@ if (buildBtn) {
       filters: window.activeFilters,
       include_charts: incChk ? incChk.checked : true,
     };
-    await fetch(`/finalize/${wizId}`, {
+    const res = await fetch(`/finalize/${wizId}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-
-    const res = await fetch(`/download/${wizId}`);
+    if (!res.ok) {
+      alert('Failed to build PDF');
+      return;
+    }
     const blob = await res.blob();
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- return the snapshot PDF directly from the finalize endpoint
- update wizard.js to download the PDF from the finalize call

## Testing
- `python -m py_compile compliance_snapshot/app/routers/wizard.py`

------
https://chatgpt.com/codex/tasks/task_e_685af8ab61d0832ca98e23c31fee9374