### PR TITLE
Remove tables from PDF generator

### DIFF
--- a/compliance_snapshot/app/services/pdf/make_snapshot.py
+++ b/compliance_snapshot/app/services/pdf/make_snapshot.py
@@ -16,50 +16,50 @@ def load_table(path: str | Path) -> pd.DataFrame:
     return pd.read_excel(p, engine="openpyxl")
 
 
-def make_snapshot(state: dict) -> Path:
-    """Create the final PDF snapshot with summary table and charts."""
+def make_snapshot(state: dict, *, include_table: bool = False) -> Path:
+    """Create the final PDF snapshot with optional table and charts."""
     df = load_table(state["csv_path"])
     chart_paths: list[str | Path] = state.get("chart_paths", [])
     out = Path(state.get("pdf_path", "snapshot.pdf"))
 
     c = rl_canvas.Canvas(str(out), pagesize=LETTER)
 
-    # ---------- COMPACT SUMMARY TABLE INSTEAD ----------
-    # Aggregation identical to stacked-bar: rows = Tags (GL/OV/SE …)
-    # columns = Violation Type, cells = counts
-    summary = (
-        df.pivot_table(
-            index="Tags",
-            columns="Violation Type",
-            aggfunc="size",
-            fill_value=0,
+    if include_table:
+        # ---------- COMPACT SUMMARY TABLE ----------
+        summary = (
+            df.pivot_table(
+                index="Tags",
+                columns="Violation Type",
+                aggfunc="size",
+                fill_value=0,
+            )
+            .reset_index()
         )
-        .reset_index()
-    )
 
-    # build data matrix for Platypus.Table
-    header = ["Region"] + summary.columns.tolist()[1:]
-    rows = summary.values.tolist()
-    table = Table([header] + rows, repeatRows=1)
+        header = ["Region"] + summary.columns.tolist()[1:]
+        rows = summary.values.tolist()
+        table = Table([header] + rows, repeatRows=1)
 
-    table.setStyle(
-        TableStyle(
-            [
-                ("BACKGROUND", (0, 0), (-1, 0), colors.black),
-                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
-                ("ALIGN", (1, 1), (-1, -1), "RIGHT"),
-                ("FONT", (0, 0), (-1, 0), "Helvetica-Bold", 8),
-                ("FONT", (0, 1), (-1, -1), "Helvetica", 7),
-                ("GRID", (0, 0), (-1, -1), 0.25, colors.grey),
-            ]
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.black),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("ALIGN", (1, 1), (-1, -1), "RIGHT"),
+                    ("FONT", (0, 0), (-1, 0), "Helvetica-Bold", 8),
+                    ("FONT", (0, 1), (-1, -1), "Helvetica", 7),
+                    ("GRID", (0, 0), (-1, -1), 0.25, colors.grey),
+                ]
+            )
         )
-    )
 
-    w, h = table.wrap(540, 400)
-    table.drawOn(c, 36, 720 - h)
+        w, h = table.wrap(540, 400)
+        table.drawOn(c, 36, 720 - h)
+        y = 720 - h - 20
+    else:
+        y = 720
 
     # ---------- chart images (unchanged) ----------
-    y = 720 - h - 20
     for img in chart_paths:
         try:
             c.drawImage(str(img), 36, y - 240, width=540, height=240)


### PR DESCRIPTION
## Summary
- refactor `pdf_builder` to no longer include tables
- add optional `include_table` parameter in `pdf_builder`
- update `pdf.make_snapshot` with optional table rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b005e6838832cbf3c4fc35ee4d87d