### PR TITLE
Add HOS violations charts

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -54,8 +54,9 @@ async def finalize(wiz_id: str, request: Request):
 
     payload = await request.json()
     filters = payload.get("filters") or {}
+    trend_end = payload.get("trend_end")
 
-    pdf_path = build_pdf(wiz_id, filters=filters)
+    pdf_path = build_pdf(wiz_id, filters=filters, trend_end=trend_end)
     return FileResponse(
         path=pdf_path,
         media_type="application/pdf",

--- a/compliance_snapshot/app/services/pdf_builder.py
+++ b/compliance_snapshot/app/services/pdf_builder.py
@@ -13,6 +13,8 @@ from reportlab.platypus import (
 from reportlab.lib.pagesizes import LETTER
 from reportlab.lib.styles import getSampleStyleSheet
 
+from .visualizations.chart_factory import make_stacked_bar, make_trend_line
+
 
 
 def load_data(wiz_id: str, table: str) -> pd.DataFrame:
@@ -28,6 +30,7 @@ def build_pdf(
     wiz_id: str,
     *,
     filters: dict | None = None,
+    trend_end: str | None = None,
     include_table: bool = False,
 ) -> Path:
     tmpdir = Path(f"/tmp/{wiz_id}")
@@ -46,6 +49,10 @@ def build_pdf(
     else:
         table_data = []
 
+    end_date = pd.to_datetime(trend_end).date() if trend_end else None
+    bar_path = make_stacked_bar(df, tmpdir / "bar.png")
+    trend_path = make_trend_line(df, end_date, tmpdir / "trend.png")
+
 
     # ----- build the PDF -----
     styles = getSampleStyleSheet()
@@ -56,5 +63,12 @@ def build_pdf(
 
     if include_table and table_data:
         story.extend([Table(table_data, repeatRows=1, hAlign="LEFT"), Spacer(1, 12)])
+
+    story.extend([
+        Image(str(bar_path), width=450, height=225),
+        Spacer(1, 12),
+        Image(str(trend_path), width=450, height=225),
+    ])
+
     doc.build(story)
     return out_path

--- a/compliance_snapshot/app/services/pdf_generator.py
+++ b/compliance_snapshot/app/services/pdf_generator.py
@@ -25,12 +25,7 @@ def build_pdf(hos_df: pd.DataFrame, end_date: Optional[date] = None) -> bytes:
         bar_path = Path(bar_tmp.name)
         trend_path = Path(trend_tmp.name)
         make_stacked_bar(hos_df, bar_path)
-        # ``make_trend_line`` in repository does not require ``end_date``
-        try:
-            make_trend_line(hos_df, trend_path)
-        except TypeError:
-            # If newer signature requires end_date
-            make_trend_line(hos_df, end_date, trend_path)  # type: ignore
+        make_trend_line(hos_df, end_date, trend_path)
 
     buffer = io.BytesIO()
     doc = SimpleDocTemplate(buffer, pagesize=letter)

--- a/compliance_snapshot/app/services/visualizations/chart_factory.py
+++ b/compliance_snapshot/app/services/visualizations/chart_factory.py
@@ -47,31 +47,43 @@ def make_chart(df, chart_type: str, out_path: Path, title: str | None = None) ->
     plt.close()
 
 
-def make_stacked_bar(df: pd.DataFrame, out_path: Path):
+def make_stacked_bar(df: pd.DataFrame, out_path: Path) -> Path:
     """Create a stacked bar chart of violation counts per region."""
 
-    plt.style.use("seaborn-v0_8-whitegrid")
+    plt.style.use("dark_background")
     df = _drop_null_rows(df, ["Tags", "Violation Type"])
 
-    regions = [
-        ("Ohio Valley", "OV"),
-        ("Great Lakes", "GL"),
-        ("Midwest", "MW"),
-        ("Southeast", "SE"),
-    ]
+    # --- normalize regions to GL, OV, SE only ---
+    regions = ["GL", "OV", "SE"]
+    region_map = {abbr: abbr for abbr in regions}
 
-    frames: list[pd.DataFrame] = []
-    for region, key in regions:
-        mask = df["Tags"].astype(str).str.contains(key, case=False, na=False)
+    df2 = pd.DataFrame(columns=["Region", "Violation Type"])
+    for abbr in regions:
+        mask = df["Tags"].astype(str).str.contains(abbr, case=False, na=False)
         sub = df[mask].copy()
         if not sub.empty:
-            sub["Region"] = region
-            frames.append(sub)
+            sub["Region"] = region_map[abbr]
+            df2 = pd.concat([df2, sub], ignore_index=True)
 
-    if frames:
-        df2 = pd.concat(frames, ignore_index=True)
-    else:
-        df2 = pd.DataFrame(columns=["Region", "Violation Type"])
+    # Normalize violation type labels
+    vt_aliases = {
+        "missing certifications": "Missing Certifications",
+        "missing certification": "Missing Certifications",
+        "shift duty limit": "Shift Duty Limit",
+        "shift driving limit": "Shift Driving Limit",
+        "cycle limit": "Cycle Limit",
+    }
+    df2["Violation Type"] = (
+        df2["Violation Type"].astype(str).str.strip().str.lower().map(vt_aliases).fillna(df2["Violation Type"])
+    )
+
+    # Only keep desired violation types
+    desired_types = [
+        "Missing Certifications",
+        "Shift Duty Limit",
+        "Shift Driving Limit",
+        "Cycle Limit",
+    ]
 
     pivot = (
         df2.pivot_table(
@@ -80,26 +92,49 @@ def make_stacked_bar(df: pd.DataFrame, out_path: Path):
             aggfunc="size",
             fill_value=0,
         )
-        .reindex([r[0] for r in regions], fill_value=0)
+        .reindex(regions, fill_value=0)
+        .reindex(columns=desired_types, fill_value=0)
     )
 
+    fig, ax = plt.subplots(figsize=(6, 3))
+    fig.patch.set_facecolor("#333333")
+    ax.set_facecolor("#333333")
+
     if pivot.empty or pivot.select_dtypes("number").empty:
-        fig, ax = plt.subplots(figsize=(6, 3))
-        ax.text(0.5, 0.5, "No data", ha="center", va="center")
+        ax.text(0.5, 0.5, "No data", ha="center", va="center", color="white")
         ax.axis("off")
     else:
-        ax = pivot.plot.bar(stacked=True, figsize=(6, 3))
-    ax.set_title("HOS Violations")
+        colors = ["#00bcd4", "#ff8c00", "#ffff00", "#808080"]
+        pivot.plot.bar(
+            stacked=True,
+            ax=ax,
+            color=colors[: len(pivot.columns)],
+            width=0.6,
+        )
+
+    ax.set_title("HOS Violations", color="white")
     ax.set_xlabel("")
-    ax.set_ylabel("Violation Count")
-    plt.xticks(rotation=0)
+    ax.set_ylabel("Violation Count", color="white")
+    ax.set_ylim(0, 120)
+    ax.set_yticks(range(0, 121, 20))
+    ax.tick_params(colors="white")
+    ax.legend(title=None, labelcolor="white")
+
+    total = int(pivot.values.sum()) if not pivot.empty else 0
+    ax.text(0.5, 1.05, f"Total {total}", transform=ax.transAxes, ha="center", color="white")
+
+    plt.xticks(rotation=0, color="white")
     plt.tight_layout()
-    plt.savefig(out_path, dpi=160)
+    plt.savefig(out_path, dpi=200)
     plt.close()
     return out_path
 
 
-def make_trend_line(df: pd.DataFrame, end_date=None, out_path: Path | None = None):
+def make_trend_line(
+    df: pd.DataFrame,
+    end_date=None,
+    out_path: Path | None = None,
+) -> Path:
     """Create a multi-line chart of weekly violation counts."""
 
     # Backwards compatibility: allow call signature (df, out_path)
@@ -113,7 +148,7 @@ def make_trend_line(df: pd.DataFrame, end_date=None, out_path: Path | None = Non
     if end_date is None:
         end_date = pd.Timestamp.utcnow().normalize().date()
 
-    plt.style.use("seaborn-v0_8-whitegrid")
+    plt.style.use("dark_background")
 
     df2 = df.copy()
 
@@ -133,18 +168,28 @@ def make_trend_line(df: pd.DataFrame, end_date=None, out_path: Path | None = Non
 
     df2 = _drop_null_rows(df2, ["week"])
 
-    target_dates = []
-    for i in reversed(range(4)):
-        d = end_date - pd.Timedelta(days=7 * i)
-        d = (pd.Timestamp(d) - pd.Timedelta(days=pd.Timestamp(d).weekday())).date()
-        target_dates.append(d)
+    # calculate the 4 Mondays ending with ``end_date``
+    end_monday = (pd.Timestamp(end_date) - pd.Timedelta(days=pd.Timestamp(end_date).weekday())).date()
+    target_dates = [end_monday - pd.Timedelta(weeks=i) for i in reversed(range(4))]
 
-    df2["week_of"] = (df2["week"] - pd.to_timedelta(df2["week"].dt.weekday, unit="D")).dt.date
+    df2["week_of"] = (
+        df2["week"] - pd.to_timedelta(df2["week"].dt.weekday, unit="D")
+    ).dt.date
     df2 = df2[df2["week_of"].isin(target_dates)]
 
     vt_col = normalized.get("violation_type")
     if vt_col:
         df2 = _drop_null_rows(df2, [vt_col])
+        vt_aliases = {
+            "missing certifications": "Missing Certifications",
+            "missing certification": "Missing Certifications",
+            "shift duty limit": "Shift Duty Limit",
+            "shift driving limit": "Shift Driving Limit",
+            "cycle limit": "Cycle Limit",
+        }
+        df2[vt_col] = (
+            df2[vt_col].astype(str).str.strip().str.lower().map(vt_aliases).fillna(df2[vt_col])
+        )
         pivot = (
             df2.pivot_table(
                 index="week_of",
@@ -153,7 +198,7 @@ def make_trend_line(df: pd.DataFrame, end_date=None, out_path: Path | None = Non
                 fill_value=0,
             )
             .reindex(target_dates, fill_value=0)
-            .sort_index(axis=1)
+            .reindex(columns=list(vt_aliases.values()), fill_value=0)
         )
     else:
         numeric_cols = [c for c in df2.columns if c not in {"week", "week_of"} and pd.api.types.is_numeric_dtype(df2[c])]
@@ -164,12 +209,34 @@ def make_trend_line(df: pd.DataFrame, end_date=None, out_path: Path | None = Non
             .reindex(target_dates, fill_value=0)
         )
 
-    colors = plt.cm.tab10.colors
-    ax = pivot.plot.line(marker="o", figsize=(7, 4), color=colors[: len(pivot.columns)])
+    colors = ["#00bcd4", "#ff8c00", "#ffff00", "#808080"]
+    fig, ax = plt.subplots(figsize=(7, 4))
+    fig.patch.set_facecolor("#333333")
+    ax.set_facecolor("#333333")
+
+    if pivot.empty or pivot.select_dtypes("number").empty:
+        ax.text(0.5, 0.5, "No data", ha="center", va="center", color="white")
+        ax.axis("off")
+    else:
+        for idx, col in enumerate(pivot.columns):
+            ax.plot(
+                range(len(target_dates)),
+                pivot[col].values,
+                marker="o",
+                color=colors[idx % len(colors)],
+                label=col,
+            )
+
     ax.set_xlabel("")
-    ax.set_ylabel("Count")
+    ax.set_ylabel("Count", color="white")
     ax.set_xticks(range(len(target_dates)))
-    ax.set_xticklabels([d.strftime("%m/%d/%Y") for d in target_dates])
+    ax.set_xticklabels([d.strftime("%m/%d/%Y") for d in target_dates], color="white")
+    ax.set_ylim(0, 200)
+    ax.set_yticks(range(0, 201, 50))
+    ax.tick_params(colors="white")
+    ax.legend(loc="upper left", frameon=False, labelcolor="white")
+    ax.set_title("HOS 4-Week Trend Analysis", color="white")
+
     plt.tight_layout()
     plt.savefig(out_path, dpi=200)
     plt.close()

--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -143,38 +143,102 @@ function drawChart(name, rows, cols){
   const canvas = document.getElementById('preview');
   if(!rows.length){ canvas.classList.add('hidden'); return; }
 
-  // Find the Violation Type column regardless of casing, spaces, or invisible
-  // sort icons that DataTables adds to the header text.
-  const normalize = s => s.toLowerCase()
-                           .replace(/[^a-z\s]/g, '')   // strip non-letters
-                           .replace(/\s+/g, '_')        // spaces \u2192 underscore
-                           .trim();
-  const vtIdx = cols.findIndex(c => normalize(c) === 'violation_type');
+  const normalize = s => s.toLowerCase().replace(/[^a-z\s]/g,'').replace(/\s+/g,'_').trim();
+  const vtIdx   = cols.findIndex(c => normalize(c) === 'violation_type');
+  const tagIdx  = cols.findIndex(c => normalize(c) === 'tags');
+  const weekIdx = cols.findIndex(c => normalize(c) === 'week');
   if(vtIdx === -1){ canvas.classList.add('hidden'); return; }
 
-  const weekIdx = cols.findIndex(c => normalize(c) === 'week');
-
-
   const ctx = canvas.getContext('2d');
-  const chosen = document.getElementById('chart-type').value;
-  document.getElementById('chart-type-hidden').value = chosen;
-
   if(window.currentChart){ window.currentChart.destroy(); }
-
   canvas.classList.remove('hidden');
+  canvas.style.backgroundColor = '#333';
 
-  {
+  const colors = {
+    'Missing Certifications': '#00bcd4',
+    'Shift Duty Limit': '#ff8c00',
+    'Shift Driving Limit': '#ffff00',
+    'Cycle Limit': '#808080'
+  };
+  const canonical = v => {
+    const t = String(v||'').toLowerCase();
+    if(t.startsWith('missing')) return 'Missing Certifications';
+    if(t.includes('duty')) return 'Shift Duty Limit';
+    if(t.includes('driving')) return 'Shift Driving Limit';
+    if(t.includes('cycle')) return 'Cycle Limit';
+    return v;
+  };
+
+  if(weekIdx !== -1){
+    const endStr = document.getElementById('trend-end').value;
+    const endDate = endStr ? new Date(endStr) : new Date(rows[rows.length-1][weekIdx]);
+    const startOfWeek = d => { const x=new Date(d); x.setDate(x.getDate()-x.getDay()); x.setHours(0,0,0,0); return x; };
+    const endMon = startOfWeek(endDate);
+    const weeks = [3,2,1,0].map(i=> new Date(endMon.getTime()-i*7*24*60*60*1000));
     const counts = {};
-    rows.forEach(r => {
-      const val = r[vtIdx];
-      if(val !== null && val !== undefined && String(val).trim().toLowerCase() !== 'null'){
-        counts[val] = (counts[val] || 0) + 1;
+    rows.forEach(r=>{
+      const type = canonical(r[vtIdx]);
+      const wk   = startOfWeek(new Date(r[weekIdx])).getTime();
+      if(!weeks.some(w=>w.getTime()===wk)) return;
+      counts[type] = counts[type] || {};
+      counts[type][wk] = (counts[type][wk]||0)+1;
+    });
+    const labels = weeks.map(w=>`${w.getMonth()+1}/${w.getDate()}/${w.getFullYear()}`);
+    const datasets = Object.entries(colors).map(([t,c])=>({
+      label: t,
+      data: weeks.map(w=>counts[t]?.[w.getTime()]||0),
+      borderColor: c,
+      backgroundColor: c,
+      fill: false
+    }));
+    window.currentChart = new Chart(ctx,{
+      type: 'line',
+      data:{ labels, datasets },
+      options:{
+        scales:{
+          x:{ ticks:{color:'white'} },
+          y:{ beginAtZero:true, max:200, ticks:{stepSize:50,color:'white'} }
+        },
+        plugins:{
+          title:{display:true,text:'HOS 4-Week Trend Analysis',color:'white'},
+          legend:{labels:{color:'white'}}
+        }
       }
     });
+    return;
+  }
+
+  if(tagIdx !== -1){
+    const regions = ['GL','OV','SE'];
+    const counts = {};
+    rows.forEach(r=>{
+      const tag = String(r[tagIdx]||'').toUpperCase();
+      const reg = regions.find(x=>tag.includes(x));
+      if(!reg) return;
+      const type = canonical(r[vtIdx]);
+      counts[reg] = counts[reg] || {};
+      counts[reg][type] = (counts[reg][type]||0)+1;
+    });
+    const datasets = Object.entries(colors).map(([t,c])=>({
+      label:t,
+      data: regions.map(r=>counts[r]?.[t]||0),
+      backgroundColor:c
+    }));
+    const total = datasets.reduce((s,d)=>s+d.data.reduce((a,b)=>a+b,0),0);
     window.currentChart = new Chart(ctx,{
-      type: chosen,
-      data:{ labels: Object.keys(counts), datasets:[{label:'count',data:Object.values(counts)}] },
-      options:{plugins:{title:{display:true,text:name}}}
+      type:'bar',
+      data:{ labels: regions, datasets },
+      options:{
+        scales:{
+          x:{ stacked:true, ticks:{color:'white'} },
+          y:{ beginAtZero:true, stacked:true, max:120, ticks:{stepSize:20,color:'white'} }
+        },
+        plugins:{
+          title:{display:true,text:'HOS Violations',color:'white'},
+          legend:{labels:{color:'white'}},
+          subtitle:{display:true,text:`Total ${total}`,color:'white'}
+        }
+      }
     });
   }
 }

--- a/static/js/wizard.js
+++ b/static/js/wizard.js
@@ -9,6 +9,7 @@ if (buildBtn) {
     e.preventDefault();
     const payload = {
       filters: window.activeFilters,
+      trend_end: document.getElementById('trend-end')?.value || null,
     };
     const res = await fetch(`/finalize/${wizId}`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- revamp `make_stacked_bar` and `make_trend_line` with new dark theme, fixed regions and color palette
- update PDF builder/generator to use new charts and trend end date
- send trend end date from wizard UI and draw matching Chart.js previews

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b19b06004832ca73420253fa86f39