### PR TITLE
Remove unused include charts option

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -39,11 +39,6 @@
     <!-- hidden field that goes to /finalize -->
     <input type="hidden" name="chart_type" id="chart-type-hidden" value="bar">
 
-    <!-- Toggle whether to include charts in the final PDF -->
-    <label style="margin-top:.5rem;display:block">
-       <input type="checkbox" id="include-charts" checked>
-       include charts
-    </label>
 
     <!-- Chart preview -->
     <canvas id="preview" class="hidden"></canvas>
@@ -105,15 +100,13 @@ async function openTab(table){
   function updatePreview(){
       const table     = $('#tbl').DataTable();
       const searchStr = table.search();
-      const include   = document.getElementById('include-charts').checked;
 
       // propagate hidden fields for /finalize
-      $('#filter-search-hidden').val(include ? searchStr : "");
+      $('#filter-search-hidden').val(searchStr);
       $('#chart-type-hidden').val(
-          include ? document.getElementById('chart-type').value : "bar"
+          document.getElementById('chart-type').value
       );
 
-      if(!include){ document.getElementById('preview').classList.add('hidden'); return; }
       document.getElementById('preview').classList.remove('hidden');
 
       const rows = searchStr ? table.rows({search:'applied'}).data().toArray()
@@ -124,8 +117,6 @@ async function openTab(table){
 
   $('#tbl').on('draw.dt', updatePreview);       // fires after search OR pagination
   document.getElementById('chart-type')
-          .addEventListener('change', updatePreview);
-  document.getElementById('include-charts')
           .addEventListener('change', updatePreview);
 
   // initial render

--- a/static/js/wizard.js
+++ b/static/js/wizard.js
@@ -1,6 +1,5 @@
 const wizId   = location.pathname.split('/').pop();
 const buildBtn = document.getElementById('build-pdf');
-const incChk   = document.getElementById('include-charts');
 
 // global object updated by table.js
 window.activeFilters = window.activeFilters || {};
@@ -11,7 +10,6 @@ if (buildBtn) {
     const payload = {
       filters: window.activeFilters,
       trend_end: document.getElementById('trend-end')?.value || null,
-      include_charts: incChk ? incChk.checked : true,
     };
     const res = await fetch(`/finalize/${wizId}`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- remove the toggle for including charts in the wizard page
- drop related JS payload parameter

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b23c67fe4832cb16acd21967e0c1f