### PR TITLE
Restrict date picker to Mondays

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -46,7 +46,7 @@
 
       <label style="display:block;margin:1rem 0">
         Trend&nbsp;end&nbsp;date:
-        <input type="date" name="trend_end" id="trend-end">
+        <input type="date" name="trend_end" id="trend-end" min="1970-01-05" step="7">
         <small>(defaults to latest week if left blank)</small>
         <small id="monday-note">(Mondays only)</small>
       </label>


### PR DESCRIPTION
## Summary
- restrict trend date input to Mondays using HTML `step` attribute

## Testing
- `pip install -r requirements.txt`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b2fc8c52c832caf34fbb28c2d2537