### PR TITLE
Upgrade insights to gpt‑4o and adjust layout

### DIFF
--- a/compliance_snapshot/app/services/pdf_builder.py
+++ b/compliance_snapshot/app/services/pdf_builder.py
@@ -105,16 +105,15 @@ def build_pdf(
             )
         )
 
+    story.append(Image(str(bar_path), width=450, height=225))
+    story.append(Spacer(1, 12))
     story.append(Paragraph(summary_insights, styles["Normal"]))
     story.append(Spacer(1, 12))
 
-    story.append(Image(str(bar_path), width=450, height=225))
-    story.append(Spacer(1, 12))
-
     story.append(Paragraph("HOS Violation Trend (4 weeks)", styles["Heading2"]))
-    story.append(Paragraph(trend_insights, styles["Normal"]))
-    story.append(Spacer(1, 12))
     story.append(Image(str(trend_path), width=450, height=225))
+    story.append(Spacer(1, 12))
+    story.append(Paragraph(trend_insights, styles["Normal"]))
 
     doc.build(story)
     return out_path

--- a/compliance_snapshot/app/services/report_generator.py
+++ b/compliance_snapshot/app/services/report_generator.py
@@ -5,12 +5,12 @@ from datetime import date
 from typing import Dict
 
 import pandas as pd
-import openai
+from openai import OpenAI
 
 from .visualizations.chart_factory import normalize_violation_types
 
-# Configure OpenAI via Replit environment variable
-openai.api_key = os.environ.get("OPEN_API_KEY")
+# Initialize OpenAI client
+client = OpenAI(api_key=os.environ.get("OPEN_API_KEY"))
 
 
 def _standardize_columns(df: pd.DataFrame) -> dict:
@@ -150,7 +150,7 @@ def _cached_summary_insights(summary_json: str) -> str:
     """Generate insights for weekly summary using OpenAI."""
     summary_data: Dict = json.loads(summary_json)
     try:
-        if not openai.api_key:
+        if not os.environ.get("OPEN_API_KEY"):
             print("WARNING: No OpenAI API key found, using fallback")
             return generate_fallback_summary_insights(summary_data)
 
@@ -168,8 +168,8 @@ def _cached_summary_insights(summary_json: str) -> str:
         Focus on: overall trend, regional patterns, concerning violations, and positive developments.
         """
 
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
+        response = client.chat.completions.create(
+            model="gpt-4o",
             messages=[{"role": "user", "content": prompt}],
             max_tokens=150,
             temperature=0.7,
@@ -234,7 +234,7 @@ def _cached_trend_insights(trend_json: str) -> str:
     """Generate insights for 4-week trend using OpenAI."""
     trend_data: Dict = json.loads(trend_json)
     try:
-        if not openai.api_key:
+        if not os.environ.get("OPEN_API_KEY"):
             print("WARNING: No OpenAI API key found, using fallback")
             return generate_fallback_trend_insights(trend_data)
 
@@ -252,8 +252,8 @@ def _cached_trend_insights(trend_json: str) -> str:
 
         Be specific about the data patterns and actionable in recommendations.
         """
-        response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
+        response = client.chat.completions.create(
+            model="gpt-4o",
             messages=[{"role": "user", "content": prompt}],
             max_tokens=200,
             temperature=0.7,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ matplotlib
 reportlab
 jinja2
 pillow
-openai
-openai
+openai>=1.3.8

--- a/templates/snapshot.html
+++ b/templates/snapshot.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+        }
+
+        h1, h2, h3 {
+            color: #333;
+        }
+
+        .summary-section {
+            margin-bottom: 20px;
+        }
+
+        .chart-container {
+            margin: 20px 0;
+        }
+
+        .insights-box {
+            background-color: #f5f5f5;
+            border-left: 4px solid #2196F3;
+            padding: 15px;
+            margin: 20px 0 40px 0;
+            font-style: italic;
+        }
+
+        .insights-box h3 {
+            margin-top: 0;
+            color: #1976D2;
+        }
+    </style>
+</head>
+<body>
+    <h1>HOS Violations Snapshot</h1>
+
+    <div class="summary-section">
+        <h2>HOS Violations Summary</h2>
+        <p><strong>Total Violations:</strong> {{ total_current }} ({{ '+' if total_change >= 0 else '' }}{{ total_change }})</p>
+
+        <p><strong>Violations by Region:</strong></p>
+        <ul>
+            {% for region, data in by_region.items() %}
+            <li>{{ region }}: {{ data.current }} ({{ '+' if data.change >= 0 else '' }}{{ data.change }})</li>
+            {% endfor %}
+        </ul>
+
+        <p><strong>Top Violation Types:</strong></p>
+        <ul>
+            {% for violation, data in by_type.items() %}
+            <li>{{ violation }}: {{ data.current }} ({{ '+' if data.change >= 0 else '' }}{{ data.change }})</li>
+            {% endfor %}
+        </ul>
+    </div>
+
+    <div class="chart-container">
+        {{ hos_violations_chart|safe }}
+    </div>
+
+    <div class="insights-box">
+        <h3>Insights:</h3>
+        <p>{{ summary_insights }}</p>
+    </div>
+
+    <h2>HOS Violation Trend (4 weeks)</h2>
+    <div class="chart-container">
+        {{ hos_trend_chart|safe }}
+    </div>
+    <div class="insights-box">
+        <h3>Insights:</h3>
+        <p>{{ trend_insights }}</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update to `openai>=1.3.8`
- use the new `OpenAI` client with `gpt-4o`
- move generated insights below their charts in the PDF
- add an HTML template showing charts with insights below

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6acbd768832cb1345cb0243a1868