### PR TITLE
Handle ReportLab font color tags

### DIFF
--- a/compliance_snapshot/app/services/pdf_builder.py
+++ b/compliance_snapshot/app/services/pdf_builder.py
@@ -22,6 +22,15 @@ from .report_generator import (
 
 from .visualizations.chart_factory import make_stacked_bar, make_trend_line
 
+import re
+
+
+def convert_html_to_reportlab(text: str) -> str:
+    """Convert HTML span tags to ReportLab font tags."""
+    if not text:
+        return ""
+    return re.sub(r'<span style="color:\s*red;">([^<]+)</span>', r'<font color="red">\1</font>', text)
+
 
 
 def load_data(wiz_id: str, table: str) -> pd.DataFrame:
@@ -68,6 +77,10 @@ def build_pdf(
     print(f"DEBUG: Generated insights: {summary_insights}")
 
     trend_insights = generate_trend_insights(trend_data)
+
+    # Convert potential HTML to ReportLab-safe tags
+    summary_insights = convert_html_to_reportlab(summary_insights)
+    trend_insights = convert_html_to_reportlab(trend_insights)
 
 
     # ----- build the PDF -----

--- a/compliance_snapshot/app/services/report_generator.py
+++ b/compliance_snapshot/app/services/report_generator.py
@@ -167,7 +167,8 @@ def _cached_summary_insights(summary_json: str) -> str:
 
         Focus on: overall trend, regional patterns, concerning violations, and positive developments.
 
-        IMPORTANT: When mentioning "Missed Rest Break" violations in your response, wrap it in HTML tags like this: <span style="color: red;">Missed Rest Break</span>"""
+        IMPORTANT: When mentioning "Missed Rest Break" violations in your response, wrap it in ReportLab font tags like this: <font color="red">Missed Rest Break</font>
+        DO NOT use HTML span tags or style attributes."""
 
         response = client.chat.completions.create(
             model="gpt-4o-mini",
@@ -250,7 +251,8 @@ def _cached_trend_insights(trend_json: str) -> str:
         2. Notable improvements or deteriorations
         3. Areas of concern that need attention
 
-        IMPORTANT: When mentioning "Missed Rest Break" violations in your response, wrap it in HTML tags like this: <span style="color: red;">Missed Rest Break</span>
+        IMPORTANT: When mentioning "Missed Rest Break" violations in your response, wrap it in ReportLab font tags like this: <font color="red">Missed Rest Break</font>
+        DO NOT use HTML span tags or style attributes.
 
         Keep the response as a single, complete paragraph without line breaks."""
         response = client.chat.completions.create(


### PR DESCRIPTION
## Summary
- add conversion from HTML span style to ReportLab font tags
- instruct GPT prompts to output `<font color>` instead of HTML span

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b727beef4832cabf428ddaf8dadbb