### PR TITLE
Fix color handling and trend insights

### DIFF
--- a/compliance_snapshot/app/services/report_generator.py
+++ b/compliance_snapshot/app/services/report_generator.py
@@ -165,10 +165,7 @@ def _cached_summary_insights(summary_json: str) -> str:
         Top Violation Types:
         {format_violation_types(summary_data.get('by_type', {}))}
 
-        Focus on: overall trend, regional patterns, concerning violations, and positive developments.
-
-        IMPORTANT: When mentioning "Missed Rest Break" violations in your response, wrap it in ReportLab font tags like this: <font color="red">Missed Rest Break</font>
-        DO NOT use HTML span tags or style attributes."""
+        Focus on: overall trend, regional patterns, concerning violations, and positive developments."""
 
         response = client.chat.completions.create(
             model="gpt-4o-mini",
@@ -251,14 +248,11 @@ def _cached_trend_insights(trend_json: str) -> str:
         2. Notable improvements or deteriorations
         3. Areas of concern that need attention
 
-        IMPORTANT: When mentioning "Missed Rest Break" violations in your response, wrap it in ReportLab font tags like this: <font color="red">Missed Rest Break</font>
-        DO NOT use HTML span tags or style attributes.
-
         Keep the response as a single, complete paragraph without line breaks."""
         response = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=200,
+            max_tokens=250,
             temperature=0.7,
         )
         insights = response.choices[0].message.content.strip()

--- a/compliance_snapshot/app/services/visualizations/chart_factory.py
+++ b/compliance_snapshot/app/services/visualizations/chart_factory.py
@@ -11,6 +11,15 @@ VIOLATION_TYPES = [
     "Missed Rest Break",
 ]
 
+# Color map aligned with ``VIOLATION_TYPES``. ``Missed Rest Break`` is red
+VIOLATION_COLORS = {
+    "Missing Certifications": "#00D9FF",
+    "Shift Duty Limit": "#FF6B35",
+    "Shift Driving Limit": "#F7931E",
+    "Cycle Limit": "#39FF14",
+    "Missed Rest Break": "#FF0000",
+}
+
 
 def _drop_null_rows(df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
     """Return ``df`` with ``NaN`` or string "null" rows removed for ``columns``."""
@@ -138,11 +147,11 @@ def make_stacked_bar(df: pd.DataFrame, out_path: Path) -> Path:
         ax.text(0.5, 0.5, "No data", ha="center", va="center", color="white")
         ax.axis("off")
     else:
-        colors = ["#00D9FF", "#FF6B35", "#F7931E", "#39FF14"]
+        colors = [VIOLATION_COLORS.get(col, "#CCCCCC") for col in pivot.columns]
         pivot.plot.bar(
             stacked=True,
             ax=ax,
-            color=colors[: len(pivot.columns)],
+            color=colors,
             width=0.6,
         )
 
@@ -242,7 +251,7 @@ def make_trend_line(
             .reindex(target_dates, fill_value=0)
         )
 
-    colors = ["#00D9FF", "#FF6B35", "#F7931E", "#39FF14"]
+    colors = [VIOLATION_COLORS.get(col, "#CCCCCC") for col in pivot.columns]
     fig, ax = plt.subplots(figsize=(7, 4))
     fig.patch.set_facecolor("#2B2B2B")
     ax.set_facecolor("#2B2B2B")
@@ -256,7 +265,7 @@ def make_trend_line(
                 range(len(target_dates)),
                 pivot[col].values,
                 marker="o",
-                color=colors[idx % len(colors)],
+                color=VIOLATION_COLORS.get(col, colors[idx % len(colors)]),
                 label=col,
             )
         handles, labels = ax.get_legend_handles_labels()


### PR DESCRIPTION
## Summary
- remove red text instructions from AI prompts
- highlight `Missed Rest Break` only in charts
- enlarge token limit for trend insights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7531a2b8832cb9fe0ffec3dc413b