### PR TITLE
Fix PDF builder chart size

### DIFF
--- a/compliance_snapshot/app/services/pdf_builder.py
+++ b/compliance_snapshot/app/services/pdf_builder.py
@@ -124,9 +124,9 @@ def build_pdf(
     story.append(Spacer(1, 20))
 
     # Add both charts at the top of the page
-    story.append(Image(str(bar_path), width=450, height=300))
+    story.append(Image(str(bar_path), width=350, height=230))
     story.append(Spacer(1, 12))
-    story.append(Image(str(trend_path), width=450, height=300))
+    story.append(Image(str(trend_path), width=350, height=230))
 
     # Force page break to start Page 2
     story.append(PageBreak())


### PR DESCRIPTION
## Summary
- reduce chart widths and heights so both charts fit on one page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c4588a98c832c9d8d4af37a087bf9