### PR TITLE
Add multi-report support

### DIFF
--- a/compliance_snapshot/app/services/processors/file_detector.py
+++ b/compliance_snapshot/app/services/processors/file_detector.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def detect_report_type(filepath: Path) -> Tuple[Optional[str], pd.DataFrame]:
+    """Detect the report type from file content."""
+    if filepath.suffix.lower() == '.csv':
+        df = pd.read_csv(filepath)
+    else:
+        df = pd.read_excel(filepath, engine='openpyxl')
+
+    cols_lower = [c.lower().strip() for c in df.columns]
+
+    if any('violation type' in col for col in cols_lower):
+        return 'hos', df
+    elif any('event type' in col for col in cols_lower) and any('driver' in col for col in cols_lower):
+        safety_cols = ['vehicle', 'status', 'review_status', 'event_url']
+        if any(any(s in col for col in cols_lower) for s in safety_cols):
+            return 'safety_inbox', df
+    elif any('personal conveyance' in col or 'pc_duration' in col for col in cols_lower):
+        return 'personnel_conveyance', df
+    elif any('unassigned' in col and 'segments' in col for col in cols_lower):
+        return 'unassigned_hos', df
+    elif any('mistdvi' in col or 'missed dvir' in col for col in cols_lower):
+        return 'mistdvi', df
+    elif any('driver' in col and 'behavior' in col for col in cols_lower):
+        return 'driver_behaviors', df
+    elif any('driver' in col and 'safety' in col and 'score' in col for col in cols_lower):
+        return 'drivers_safety', df
+
+    filename_lower = filepath.stem.lower()
+    if 'hos' in filename_lower and 'violation' in filename_lower:
+        return 'hos', df
+    elif 'safety' in filename_lower and 'inbox' in filename_lower:
+        return 'safety_inbox', df
+
+    return 'hos', df

--- a/compliance_snapshot/app/services/processors/safety_inbox.py
+++ b/compliance_snapshot/app/services/processors/safety_inbox.py
@@ -1,0 +1,86 @@
+import pandas as pd
+from pathlib import Path
+from typing import Dict, Any
+
+
+def process_safety_inbox(df: pd.DataFrame) -> pd.DataFrame:
+    """Process Safety Inbox Report data with actual column structure."""
+    # Normalize column names
+    df.columns = [c.strip().lower().replace(" ", "_") for c in df.columns]
+
+    # Check if this looks like a safety inbox report
+    if 'event_type' not in df.columns or 'driver' not in df.columns:
+        raise ValueError(
+            "This doesn't appear to be a Safety Inbox Report - missing Event Type or Driver columns"
+        )
+
+    # Convert time column
+    if 'time' in df.columns:
+        df['time'] = pd.to_datetime(df['time'], errors='coerce')
+
+    string_cols = [
+        'vehicle', 'driver', 'driver_tags', 'event_type', 'status',
+        'location', 'assigned_coach', 'device_tags', 'review_status'
+    ]
+    for col in string_cols:
+        if col in df.columns:
+            df[col] = df[col].astype(str).str.strip()
+            df[col] = df[col].replace('nan', '')
+
+    return df
+
+
+def summarize(path: Path) -> Dict[str, Any]:
+    """Summarize safety inbox report by aggregating events."""
+    if path.suffix.lower() == ".csv":
+        df = pd.read_csv(path)
+    else:
+        df = pd.read_excel(path, engine="openpyxl")
+
+    df = process_safety_inbox(df)
+
+    total_events = len(df)
+
+    events_by_type = {}
+    if 'event_type' in df.columns:
+        event_counts = df['event_type'].value_counts()
+        events_by_type = event_counts.to_dict()
+
+    events_by_status = {}
+    if 'status' in df.columns:
+        status_counts = df['status'].value_counts()
+        events_by_status = status_counts.to_dict()
+
+    events_by_review = {}
+    if 'review_status' in df.columns:
+        review_counts = df['review_status'].value_counts()
+        events_by_review = review_counts.to_dict()
+
+    top_drivers = {}
+    if 'driver' in df.columns:
+        driver_counts = df['driver'].value_counts().head(10)
+        top_drivers = driver_counts.to_dict()
+
+    events_by_region = {}
+    if 'driver_tags' in df.columns:
+        region_patterns = {
+            'great lakes': ['great lakes', 'gl', 'great_lakes'],
+            'ohio valley': ['ohio valley', 'ov', 'ohio_valley'],
+            'southeast': ['southeast', 'se', 'south east'],
+            'midwest': ['midwest', 'mw', 'mid west'],
+            'corporate': ['corporate', 'corp']
+        }
+        for region, patterns in region_patterns.items():
+            mask = df['driver_tags'].str.lower().str.contains('|'.join(patterns), na=False)
+            count = mask.sum()
+            if count > 0:
+                events_by_region[region] = int(count)
+
+    return {
+        "total_events": total_events,
+        "events_by_type": events_by_type,
+        "events_by_status": events_by_status,
+        "events_by_review": events_by_review,
+        "top_drivers": top_drivers,
+        "events_by_region": events_by_region,
+    }

--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -277,11 +277,26 @@ async function loadTabs(){
   const res = await fetch(`/api/${ticket}/tables`);
   const tables = await res.json();
   const nav = document.getElementById('tabs');
-  tables.forEach(name=>{
+
+  const tableNames = {
+    'hos': 'HOS Violations',
+    'safety_inbox': 'Safety Inbox',
+    'personnel_conveyance': 'Personal Conveyance',
+    'unassigned_hos': 'Unassigned HOS',
+    'mistdvi': 'Missed DVIR',
+    'driver_behaviors': 'Driver Behaviors',
+    'drivers_safety': 'Driver Safety'
+  };
+
+  tables.forEach((name, index) => {
     const btn = document.createElement('button');
     btn.type = "button";
-    btn.textContent = name.toUpperCase();
-    btn.onclick = ()=> openTab(name);
+    btn.textContent = tableNames[name] || name.toUpperCase();
+    btn.onclick = () => openTab(name);
+    if(index === 0){
+      btn.classList.add('active');
+      setTimeout(() => openTab(name), 100);
+    }
     nav.appendChild(btn);
   });
 }
@@ -292,6 +307,23 @@ async function openTab(table){
   const res = await fetch(`/api/${ticket}/query?table=${table}`);
   const {columns, rows} = await res.json();
   window.tableName = table;  // remember current table
+
+  const tableNames = {
+    'hos': 'HOS Violations',
+    'safety_inbox': 'Safety Inbox',
+    'personnel_conveyance': 'Personal Conveyance',
+    'unassigned_hos': 'Unassigned HOS',
+    'mistdvi': 'Missed DVIR',
+    'driver_behaviors': 'Driver Behaviors',
+    'drivers_safety': 'Driver Safety'
+  };
+
+  document.querySelectorAll('nav#tabs button').forEach(btn => {
+    btn.classList.remove('active');
+    if(btn.textContent === (tableNames[table] || table.toUpperCase())){
+      btn.classList.add('active');
+    }
+  });
 
   window.activeFilters = window.activeFilters || {};
   const filters = window.activeFilters;


### PR DESCRIPTION
## Summary
- process Safety Inbox reports with new processor
- automatically detect report types during upload
- support multiple report uploads in upload router
- improve wizard tab handling and names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbd5ce344832c8a2d91032883ca4a