### PR TITLE
Fix safety inbox dropdown width

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -102,6 +102,10 @@
         color: #334155;
         font-size: 0.875rem;
         transition: border-color 0.3s ease;
+        max-width: 260px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
     
     #filters select:focus {


### PR DESCRIPTION
## Summary
- limit the width of each filter dropdown so long values like the Safety Inbox `Event URL` won't expand outside the viewport

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd3748094832c8ee42e8b08813376