### PR TITLE
Fix upload table name detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/compliance_snapshot/app/routers/upload.py
+++ b/compliance_snapshot/app/routers/upload.py
@@ -58,14 +58,7 @@ async def generate(background_tasks: BackgroundTasks, files: list[UploadFile] = 
             continue
 
         try:
-            if len(saved_files) == 1:
-                report_type = "hos"
-                if file_path.suffix.lower() == ".csv":
-                    df = pd.read_csv(file_path)
-                else:
-                    df = pd.read_excel(file_path, engine="openpyxl")
-            else:
-                report_type, df = file_detector.detect_report_type(file_path)
+            report_type, df = file_detector.detect_report_type(file_path)
         except Exception as exc:
             logger.exception("Failed to read %s", file.filename)
             record_failure(file.filename, exc)

--- a/compliance_snapshot/tests/test_upload.py
+++ b/compliance_snapshot/tests/test_upload.py
@@ -1,0 +1,51 @@
+import os
+import pandas as pd
+from pathlib import Path as _P
+import sys
+
+ROOT = _P(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("OPEN_API_KEY", "test")
+from app.main import app
+
+
+def test_upload_safety_inbox(tmp_path):
+    cols = [
+        "Time",
+        "Vehicle",
+        "Driver",
+        "Driver Tags",
+        "Event Type",
+        "Status",
+        "Location",
+        "Event URL",
+        "Assigned Coach",
+        "Device Tags",
+        "Review Status",
+    ]
+    df = pd.DataFrame([], columns=cols)
+    path = tmp_path / "safety_inbox.csv"
+    df.to_csv(path, index=False)
+
+    client = TestClient(app)
+    with path.open("rb") as fh:
+        resp = client.post(
+            "/generate",
+            files={"files": ("safety_inbox.csv", fh, "text/csv")},
+            allow_redirects=False,
+        )
+    assert resp.status_code == 303
+    loc = resp.headers["location"]
+    assert loc.startswith("/wizard/")
+    ticket = loc.split("/")[-1]
+
+    tables_resp = client.get(f"/api/{ticket}/tables")
+    assert tables_resp.status_code == 200
+    tables = tables_resp.json()
+    assert tables == ["safety_inbox"]
+
+    wizard_resp = client.get(f"/wizard/{ticket}")
+    assert wizard_resp.status_code == 200


### PR DESCRIPTION
## Summary
- always use `detect_report_type` regardless of file count
- add regression test for single Safety Inbox upload
- ignore Python cache files

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd75c60cc832c9775ee7c411198b5