### PR TITLE
Wrap long text in filter dropdowns

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -107,6 +107,12 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
+
+    /* Allow long option text to wrap inside dropdowns */
+    #filters select option {
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
     
     #filters select:focus {
         outline: none;


### PR DESCRIPTION
## Summary
- ensure filter dropdown options wrap onto multiple lines

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd93dfa3c832cbf5b86b309664fe5