### PR TITLE
Handle timedelta columns in personnel conveyance data

### DIFF
--- a/compliance_snapshot/app/services/processors/personnel_conveyance.py
+++ b/compliance_snapshot/app/services/processors/personnel_conveyance.py
@@ -36,6 +36,22 @@ def process_personnel_conveyance(df: pd.DataFrame) -> pd.DataFrame:
     # Normalize column names
     df.columns = [c.strip().lower().replace(" ", "_").replace("(", "").replace(")", "") for c in df.columns]
 
+    # Convert timedelta objects to string format HH:MM:SS
+    for col in df.columns:
+        if df[col].dtype == 'timedelta64[ns]':
+            # Convert timedelta to string in HH:MM:SS format
+            df[col] = df[col].apply(lambda x: str(x).split(' ')[-1] if pd.notna(x) else '')
+
+    # Also specifically check the duration column
+    duration_col = None
+    for col in df.columns:
+        if 'duration' in col and 'personal' in col:
+            duration_col = col
+            break
+
+    if duration_col and df[duration_col].dtype == 'timedelta64[ns]':
+        df[duration_col] = df[duration_col].apply(lambda x: str(x).split(' ')[-1] if pd.notna(x) else '')
+
     # Expected columns
     expected_cols = [
         'date', 'driver_name', 'eld_exempt', 'eld_exempt_reason',


### PR DESCRIPTION
## Summary
- normalize excel duration columns loaded as `timedelta64[ns]`
- add conversions in `process_personnel_conveyance`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68604b2621ac832c93b047604bee1fea