### PR TITLE
Handle timedelta columns in uploads

### DIFF
--- a/compliance_snapshot/app/core/utils.py
+++ b/compliance_snapshot/app/core/utils.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 from fastapi import UploadFile
+import pandas as pd
+import datetime
 
 async def save_uploads(folder: Path, files: list[UploadFile]):
     """Save uploaded files to disk without loading into memory."""
@@ -18,4 +20,18 @@ async def save_uploads(folder: Path, files: list[UploadFile]):
                 if not chunk:
                     break
                 out.write(chunk)
+
+
+def sanitize_for_sql(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert dtypes like ``timedelta`` to strings so SQLite can store them."""
+    for col in df.columns:
+        if pd.api.types.is_timedelta64_dtype(df[col]):
+            df[col] = df[col].astype(str)
+        elif df[col].dtype == object and df[col].map(
+            lambda x: isinstance(x, datetime.timedelta)
+        ).any():
+            df[col] = df[col].apply(
+                lambda x: str(x) if isinstance(x, datetime.timedelta) else x
+            )
+    return df
 

--- a/compliance_snapshot/app/routers/upload.py
+++ b/compliance_snapshot/app/routers/upload.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import uuid
 import json
 
-from ..core.utils import save_uploads
+from ..core.utils import save_uploads, sanitize_for_sql
 from ..services.processors import file_detector
 import sqlite3
 import pandas as pd
@@ -67,6 +67,7 @@ async def generate(background_tasks: BackgroundTasks, files: list[UploadFile] = 
 
         table_name = report_type or "hos"
         try:
+            sanitize_for_sql(df)
             df.to_sql(table_name, db, if_exists="replace", index=False)
             logger.info("Saved %s as '%s' table", file.filename, table_name)
             successes.append(file.filename)


### PR DESCRIPTION
## Summary
- ensure uploaded DataFrames convert `timedelta` columns to strings before being stored in SQLite
- update `upload.py` to sanitize DataFrames prior to `to_sql`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604c7f27f4832cad95043ade630bd5