### PR TITLE
Fix missing import for unassigned driving summary

### DIFF
--- a/compliance_snapshot/app/services/visualizations/chart_factory.py
+++ b/compliance_snapshot/app/services/visualizations/chart_factory.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pandas as pd
 from typing import Dict
 
+from ..report_generator import generate_unassigned_driving_summary
+
 VIOLATION_TYPES = [
     "Missing Certifications",
     "Shift Duty Limit",


### PR DESCRIPTION
## Summary
- fix missing import in `chart_factory.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: circular import)*

------
https://chatgpt.com/codex/tasks/task_e_6861a09f461c832cbcdfeaec7e97c61f