### PR TITLE
Remove unassigned driving chart

### DIFF
--- a/compliance_snapshot/app/services/pdf_builder.py
+++ b/compliance_snapshot/app/services/pdf_builder.py
@@ -32,7 +32,6 @@ from .report_generator import (
 from .visualizations.chart_factory import (
     make_stacked_bar,
     make_trend_line,
-    make_unassigned_bar_chart,
     make_pc_usage_bar_chart,
 )
 
@@ -313,12 +312,13 @@ def build_pdf(
                     unassigned_df, end_date or pd.Timestamp.utcnow().date()
                 )
 
-                # Only add chart if we have regional data
-                if unassigned_data.get('region_data'):
-                    unassigned_bar_path = make_unassigned_bar_chart(
-                        unassigned_df, tmpdir / "unassigned_bar.png"
-                    )
-                    story.append(Image(str(unassigned_bar_path), width=450, height=300))
+
+                # Unassigned driving chart removed per new requirements
+                # if unassigned_data.get('region_data'):
+                #     unassigned_bar_path = make_unassigned_bar_chart(
+                #         unassigned_df, tmpdir / "unassigned_bar.png"
+                #     )
+                #     story.append(Image(str(unassigned_bar_path), width=450, height=300))
 
                 # Add insights regardless
                 story.append(Spacer(1, 20))


### PR DESCRIPTION
## Summary
- stop importing `make_unassigned_bar_chart`
- comment out unassigned driving chart generation in `build_pdf`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a4c77c00832c8b7d2ec63288c63e