### PR TITLE
Fix Driver Safety report routing

### DIFF
--- a/compliance_snapshot/app/services/processors/file_detector.py
+++ b/compliance_snapshot/app/services/processors/file_detector.py
@@ -73,6 +73,8 @@ def detect_report_type(filepath: Path) -> Tuple[Optional[str], pd.DataFrame]:
         report_type = 'mistdvi'
     elif any('driver' in col and 'behavior' in col for col in cols_norm):
         report_type = 'driver_behaviors'
+    elif any('driver' in col and 'safety' in col for col in cols_norm) and any('rank' in col for col in cols_norm) and not any('harsh' in col or 'speeding' in col for col in cols_norm) and not any('behavior' in col for col in cols_norm):
+        report_type = 'driver_safety'
     elif any('safety score' in col for col in cols_norm) and any('driver name' in col for col in cols_norm):
         # If we have safety score and driver name, it's likely a safety behavior report
         report_type = 'driver_behaviors'
@@ -81,6 +83,8 @@ def detect_report_type(filepath: Path) -> Tuple[Optional[str], pd.DataFrame]:
         if any('driver' in col for col in cols_norm):
             report_type = 'driver_behaviors'
     elif any('driver' in col and 'safety' in col and 'score' in col for col in cols_norm):
+        report_type = 'driver_safety'
+    elif any('safety score' in col for col in cols_norm) and any('drive time' in col for col in cols_norm):
         report_type = 'driver_safety'
     elif any('trip id' in col or 'trip_id' in col for col in cols_norm):
         if any('vehicle' in col for col in cols_norm) and any('driver' in col for col in cols_norm):

--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -314,7 +314,8 @@ const TABLE_NAMES = {
   'mistdvi': 'Missed DVIR',
   'driver_behaviors': 'Safety Behaviors',
   'driver_safety': 'Driver Safety',
-  'drivers_safety': 'Driver Safety'
+  'drivers_safety': 'Driver Safety',
+  'driver_safety_report': 'Driver Safety'
 };
 
 // keep reference to the active DataTable instance
@@ -581,6 +582,7 @@ function drawChart(name, rows, cols){
   if(!rows.length){ canvas.classList.add('hidden'); return; }
 
   const tableName = window.tableName;
+  console.log('Current table name:', tableName);
   const chartType = document.getElementById("chart-type").value;
   if(tableName === "personnel_conveyance"){
     window.drawPCCharts(name, rows, cols, chartType);
@@ -601,7 +603,7 @@ function drawChart(name, rows, cols){
       window.drawMissedDVIRCharts(name, rows, cols, chartType);
       return;
     }
-  }else if(tableName === 'driver_safety' || tableName === 'drivers_safety'){
+  }else if(tableName === 'driver_safety' || tableName === 'drivers_safety' || tableName === 'driver_safety_report'){
     if(window.drawDriverSafetyCharts){
       window.drawDriverSafetyCharts(name, rows, cols, chartType);
       return;

--- a/compliance_snapshot/tests/test_file_detector.py
+++ b/compliance_snapshot/tests/test_file_detector.py
@@ -145,3 +145,31 @@ def test_detect_driver_safety_by_filename(tmp_path):
 
     report, _ = detect_report_type(path)
     assert report == 'driver_safety'
+
+
+def test_detect_driver_safety_by_rank_and_safety_cols(tmp_path):
+    cols = [
+        'Driver Safety Rank',
+        'Driver Name',
+        'Safety Score'
+    ]
+    df = pd.DataFrame([], columns=cols)
+    path = tmp_path / 'ds_rank.csv'
+    df.to_csv(path, index=False)
+
+    report, _ = detect_report_type(path)
+    assert report == 'driver_safety'
+
+
+def test_detect_driver_safety_by_score_drive_time(tmp_path):
+    cols = [
+        'Safety Score',
+        'Total Drive Time',
+        'Some Other'
+    ]
+    df = pd.DataFrame([], columns=cols)
+    path = tmp_path / 'ds_drive.csv'
+    df.to_csv(path, index=False)
+
+    report, _ = detect_report_type(path)
+    assert report == 'driver_safety'


### PR DESCRIPTION
## Summary
- handle all driver safety table names in wizard
- log table name to help debugging
- update file detector logic for driver safety
- test driver safety detection for new cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f99773a8832c9ad7a0d1e77e869a