### PR TITLE
Fix import for DOT risk assessment

### DIFF
--- a/compliance_snapshot/app/services/pdf_builder.py
+++ b/compliance_snapshot/app/services/pdf_builder.py
@@ -27,6 +27,7 @@ from .report_generator import (
     generate_unassigned_driving_summary,  # Added missing import
     generate_unassigned_driving_insights,
     generate_unassigned_segment_details,
+    generate_dot_risk_assessment,
 )
 
 from .visualizations.chart_factory import (


### PR DESCRIPTION
## Summary
- import `generate_dot_risk_assessment` in `pdf_builder`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863064f6c88832cb1915db0223c4cad