### PR TITLE
Improve PDF chart layout and formatting

### DIFF
--- a/compliance_snapshot/app/services/pdf_builder.py
+++ b/compliance_snapshot/app/services/pdf_builder.py
@@ -149,7 +149,14 @@ def build_pdf(
 
     # ----- build the PDF -----
     styles = getSampleStyleSheet()
-    doc = SimpleDocTemplate(str(out_path), pagesize=LETTER)
+    doc = SimpleDocTemplate(
+        str(out_path),
+        pagesize=LETTER,
+        topMargin=0.5 * inch,
+        bottomMargin=0.5 * inch,
+        leftMargin=0.75 * inch,
+        rightMargin=0.75 * inch,
+    )
 
     # Create custom styles
     title_style = ParagraphStyle(
@@ -167,8 +174,8 @@ def build_pdf(
         parent=styles['Heading2'],
         fontSize=14,
         textColor=colors.HexColor('#000000'),
-        spaceAfter=12,
-        spaceBefore=20
+        spaceAfter=8,
+        spaceBefore=12
     )
 
     normal_bold = ParagraphStyle(
@@ -192,7 +199,7 @@ def build_pdf(
 
     # Main title
     story.append(Paragraph("DOT COMPLIANCE SNAPSHOT", title_style))
-    story.append(Spacer(1, 20))
+    story.append(Spacer(1, 12))
 
     # Create the date/location/position table
     header_end_date = end_date or pd.Timestamp.utcnow().date()
@@ -228,7 +235,7 @@ def build_pdf(
     ]))
 
     story.append(header_table)
-    story.append(Spacer(1, 30))
+    story.append(Spacer(1, 12))
 
     # Add the fleet safety snapshot subtitle with date range
     fleet_snapshot_title = Paragraph(
@@ -243,7 +250,7 @@ def build_pdf(
         )
     )
     story.append(fleet_snapshot_title)
-    story.append(Spacer(1, 20))
+    story.append(Spacer(1, 12))
 
     chart_paths = {
         "hos_violation": bar_path,
@@ -255,7 +262,7 @@ def build_pdf(
 
     if create_dashboard:
         story.append(Paragraph("<b>Visual Dashboard</b>", section_title_style))
-        story.append(Spacer(1, 20))
+        story.append(Spacer(1, 12))
 
         chart_data = []
         row1 = []
@@ -294,12 +301,12 @@ def build_pdf(
 
     # PAGE 1: HOS Violations Charts
     story.append(Paragraph("<b>HOS Violations Analysis</b>", section_title_style))
-    story.append(Spacer(1, 20))
+    story.append(Spacer(1, 12))
 
     if "hos_violation" in chart_paths:
         img = Image(str(chart_paths["hos_violation"]), width=5 * inch, height=3 * inch)
         story.append(img)
-        story.append(Spacer(1, 20))
+        story.append(Spacer(1, 12))
 
     if "trend" in chart_paths:
         img = Image(str(chart_paths["trend"]), width=5 * inch, height=3 * inch)
@@ -309,12 +316,12 @@ def build_pdf(
 
     # PAGE 2: Safety Events and Unassigned Driving
     story.append(Paragraph("<b>Safety Events and Unassigned Driving Analysis</b>", section_title_style))
-    story.append(Spacer(1, 20))
+    story.append(Spacer(1, 12))
 
     if "safety_events" in chart_paths:
         img = Image(str(chart_paths["safety_events"]), width=5 * inch, height=3 * inch)
         story.append(img)
-        story.append(Spacer(1, 30))
+        story.append(Spacer(1, 12))
 
     if "unassigned_segments" in chart_paths:
         img = Image(str(chart_paths["unassigned_segments"]), width=6 * inch, height=3 * inch)
@@ -324,7 +331,7 @@ def build_pdf(
 
     # PAGE 3: Speeding Analysis
     story.append(Paragraph("<b>Speeding Events Analysis</b>", section_title_style))
-    story.append(Spacer(1, 20))
+    story.append(Spacer(1, 12))
 
     if "speeding_events" in chart_paths:
         img = Image(str(chart_paths["speeding_events"]), width=4 * inch, height=4 * inch)
@@ -371,12 +378,12 @@ def build_pdf(
         ('RIGHTPADDING', (0, 0), (-1, -1), 0),
     ]))
     story.append(summary_table)
-    story.append(Spacer(1, 20))
+    story.append(Spacer(1, 12))
 
     # Summary Insights section
     story.append(Paragraph("<b>Insights:</b>", normal_bold))
     story.append(Paragraph(summary_insights, styles['Normal']))
-    story.append(Spacer(1, 30))
+    story.append(Spacer(1, 12))
 
     # HOS Violation Trend section
     story.append(Paragraph("<b>HOS Violation Trend (4 weeks)</b>", section_title_style))
@@ -391,7 +398,7 @@ def build_pdf(
         safety_inbox_df = load_data(wiz_id, "safety_inbox")
         if not safety_inbox_df.empty:
             # Safety Inbox Events Analysis section
-            story.append(Spacer(1, 30))
+            story.append(Spacer(1, 12))
             story.append(Paragraph("<b>Safety Inbox Events Analysis</b>", section_title_style))
 
             # Generate summary data
@@ -425,7 +432,7 @@ def build_pdf(
                 ('RIGHTPADDING', (0, 0), (-1, -1), 0),
             ]))
             story.append(safety_table)
-            story.append(Spacer(1, 20))
+            story.append(Spacer(1, 12))
 
             # Add insights
             story.append(Paragraph("<b>Insights:</b>", normal_bold))
@@ -440,7 +447,7 @@ def build_pdf(
     try:
         pc_df = load_data(wiz_id, "personnel_conveyance")
         if not pc_df.empty:
-            story.append(Spacer(1, 30))
+            story.append(Spacer(1, 12))
             story.append(Paragraph("Personal Conveyance (PC) Usage", section_title_style))
 
             pc_data = generate_pc_usage_summary(pc_df, end_date or pd.Timestamp.utcnow().date())
@@ -479,10 +486,10 @@ def build_pdf(
             story.append(Spacer(1, 12))
 
             pc_bar_path = make_pc_usage_bar_chart(pc_df, tmpdir / "pc_bar.png")
-            story.append(Spacer(1, 20))
+            story.append(Spacer(1, 12))
             story.append(Image(str(pc_bar_path), width=400, height=250))
 
-            story.append(Spacer(1, 20))
+            story.append(Spacer(1, 12))
             story.append(Paragraph("<b>Insights:</b>", normal_bold))
             pc_insights = generate_pc_usage_insights(pc_data)
             pc_insights = convert_html_to_reportlab(pc_insights)
@@ -494,7 +501,7 @@ def build_pdf(
     try:
         unassigned_df = load_data(wiz_id, "unassigned_hos")
         if not unassigned_df.empty:
-            story.append(Spacer(1, 30))
+            story.append(Spacer(1, 12))
 
             try:
                 # Generate summary data
@@ -511,14 +518,14 @@ def build_pdf(
                 #     story.append(Image(str(unassigned_bar_path), width=450, height=300))
 
                 # Add insights regardless
-                story.append(Spacer(1, 20))
+                story.append(Spacer(1, 12))
                 story.append(Paragraph("<b>Insights:</b>", normal_bold))
                 first_insights = generate_unassigned_driving_insights(unassigned_data)
                 first_insights = convert_html_to_reportlab(first_insights)
                 story.append(Paragraph(first_insights, styles['Normal']))
 
                 # Add section header and second insights
-                story.append(Spacer(1, 30))
+                story.append(Spacer(1, 12))
                 story.append(Paragraph("<b>Unassigned Driving Segments</b>", section_title_style))
                 story.append(Spacer(1, 12))
                 story.append(Paragraph("<b>Insights:</b>", normal_bold))
@@ -565,7 +572,7 @@ def build_pdf(
     try:
         mistdvi_df = load_data(wiz_id, "mistdvi")
         if not mistdvi_df.empty:
-            story.append(Spacer(1, 30))
+            story.append(Spacer(1, 12))
             story.append(Paragraph("<b>Missed DVIRs (Pre/Post Trip Reports)</b>", section_title_style))
             story.append(Spacer(1, 12))
 
@@ -613,7 +620,7 @@ def build_pdf(
             story.append(dvir_table)
 
             # Add insights AFTER the table
-            story.append(Spacer(1, 20))
+            story.append(Spacer(1, 12))
             story.append(Paragraph("<b>Insights:</b>", normal_bold))
             dvir_insights = generate_missed_dvir_insights(dvir_data)
             dvir_insights = convert_html_to_reportlab(dvir_insights)
@@ -625,7 +632,7 @@ def build_pdf(
     # Overall DOT Risk Assessment section
     story.append(PageBreak())
     story.append(Paragraph("<b>Overall DOT Risk Assessment</b>", section_title_style))
-    story.append(Spacer(1, 20))
+    story.append(Spacer(1, 12))
 
     risk_assessment = generate_dot_risk_assessment(
         summary_data,
@@ -636,7 +643,7 @@ def build_pdf(
         dvir_data if 'dvir_data' in locals() else None,
     )
 
-    risk_assessment = risk_assessment.replace('####', '')
+    risk_assessment = risk_assessment.replace('####', '').replace('###', '')
     risk_assessment = re.sub(
         r"(overall DOT risk level is assessed as\s*)(High|Medium|Low)",
         lambda m: m.group(1) + f"<b>{m.group(2)}</b>",

--- a/compliance_snapshot/app/services/report_generator.py
+++ b/compliance_snapshot/app/services/report_generator.py
@@ -1027,7 +1027,10 @@ Provide a 2-3 paragraph assessment covering:
             max_tokens=400,
             temperature=0.7,
         )
-        return response.choices[0].message.content.strip()
+
+        assessment = response.choices[0].message.content.strip()
+        assessment = assessment.replace('###', '').replace('##', '').strip()
+        return assessment
     except Exception:
         return generate_fallback_risk_assessment(hos_data, safety_data)
 

--- a/compliance_snapshot/app/services/visualizations/chart_factory.py
+++ b/compliance_snapshot/app/services/visualizations/chart_factory.py
@@ -4,6 +4,17 @@ from pathlib import Path
 import pandas as pd
 from typing import Dict
 
+# Apply consistent styling defaults for all charts
+plt.rcParams.update({
+    'font.size': 12,
+    'axes.titlesize': 16,
+    'axes.labelsize': 14,
+    'xtick.labelsize': 12,
+    'ytick.labelsize': 12,
+    'legend.fontsize': 12,
+    'figure.dpi': 100,
+})
+
 
 def _standardize_columns(df: pd.DataFrame) -> dict:
     """Return mapping of normalized column names to actual names."""
@@ -111,7 +122,7 @@ def make_chart(df, chart_type: str, out_path: Path, title: str | None = None) ->
         plt.title(title)
 
     plt.tight_layout(rect=[0, 0, 1, 0.95])
-    plt.savefig(out_path, dpi=300)
+    plt.savefig(out_path, dpi=400)
     plt.close()
 
 
@@ -186,7 +197,7 @@ def make_stacked_bar(df: pd.DataFrame, out_path: Path) -> Path:
     plt.xticks(rotation=0)
     plt.subplots_adjust(right=0.8)
     plt.tight_layout(rect=[0, 0, 1, 0.95])
-    plt.savefig(out_path, dpi=300)
+    plt.savefig(out_path, dpi=400)
     plt.close()
     return out_path
 
@@ -241,7 +252,7 @@ def make_unassigned_bar_chart(df: pd.DataFrame, out_path: Path) -> Path:
     ax.spines["right"].set_visible(False)
 
     plt.tight_layout()
-    plt.savefig(out_path, dpi=200, bbox_inches="tight", facecolor="#CCCCCC")
+    plt.savefig(out_path, dpi=400, bbox_inches="tight", facecolor="#CCCCCC")
     plt.close()
     return out_path
 
@@ -307,7 +318,7 @@ def make_pc_usage_bar_chart(df: pd.DataFrame, out_path: Path) -> Path:
 
     ax.grid(True, axis='y', alpha=0.3)
     plt.tight_layout()
-    plt.savefig(out_path, dpi=200, bbox_inches='tight')
+    plt.savefig(out_path, dpi=400, bbox_inches='tight')
     plt.close()
 
     return out_path
@@ -428,7 +439,7 @@ def make_trend_line(
 
     plt.subplots_adjust(right=0.8)
     plt.tight_layout(rect=[0, 0, 1, 0.95])
-    plt.savefig(out_path, dpi=300)
+    plt.savefig(out_path, dpi=400)
     plt.close()
     return out_path
 
@@ -447,7 +458,7 @@ def make_safety_events_bar(df: pd.DataFrame, out_path: Path) -> Path:
         ax.set_facecolor("#2B2B2B")
         ax.text(0.5, 0.5, "No data", ha="center", va="center", color="white")
         ax.axis("off")
-        plt.savefig(out_path, dpi=300, bbox_inches='tight')
+        plt.savefig(out_path, dpi=400, bbox_inches='tight')
         plt.close()
         return out_path
 
@@ -484,16 +495,32 @@ def make_safety_events_bar(df: pd.DataFrame, out_path: Path) -> Path:
     ax.text(0.5, -0.15, f"TOTAL EVENTS: {total}", transform=ax.transAxes,
             ha="center", color="#FF9900", fontweight='bold')
 
-    event_types = ["Following Distance", "Harsh Turn", "Harsh brake, Defensive Driving", "Defensive Driving"]
+    event_types = [
+        "Following Distance",
+        "Harsh Turn",
+        "Harsh brake, Defensive Driving",
+        "Defensive Driving",
+    ]
     colors = ["#FFFFFF", "#FF9900", "#F7931E", "#00D9FF"]
 
+    legend_handles = []
     for event, color in zip(event_types, colors):
-        ax.plot([], [], 'o', color=color, label=event, markersize=8)
+        legend_handles.append(
+            plt.Line2D([0], [0], marker="o", color="w", markerfacecolor=color, markersize=10, label=event)
+        )
 
-    ax.legend(loc='upper right', frameon=False, labelcolor='white', fontsize=8)
+    ax.legend(
+        handles=legend_handles,
+        loc="center left",
+        bbox_to_anchor=(1.05, 0.5),
+        frameon=False,
+        labelcolor="white",
+        fontsize=10,
+    )
 
     plt.tight_layout()
-    plt.savefig(out_path, dpi=300, bbox_inches='tight', facecolor="#2B2B2B")
+    plt.subplots_adjust(right=0.7)
+    plt.savefig(out_path, dpi=400, bbox_inches='tight', facecolor="#2B2B2B")
     plt.close()
     return out_path
 
@@ -512,7 +539,7 @@ def make_unassigned_segments_visual(df: pd.DataFrame, out_path: Path) -> Path:
         ax.set_facecolor("#2B2B2B")
         ax.text(0.5, 0.5, "No unassigned segments data", ha="center", va="center", color="white")
         ax.axis("off")
-        plt.savefig(out_path, dpi=300, bbox_inches='tight')
+        plt.savefig(out_path, dpi=400, bbox_inches='tight')
         plt.close()
         return out_path
 
@@ -552,7 +579,7 @@ def make_unassigned_segments_visual(df: pd.DataFrame, out_path: Path) -> Path:
             color="white", fontweight='bold', fontsize=14)
 
     plt.tight_layout()
-    plt.savefig(out_path, dpi=300, bbox_inches='tight', facecolor="#2B2B2B")
+    plt.savefig(out_path, dpi=400, bbox_inches='tight', facecolor="#2B2B2B")
     plt.close()
     return out_path
 
@@ -561,41 +588,53 @@ def make_speeding_pie_chart(df: pd.DataFrame, out_path: Path) -> Path:
     """Create pie chart of speeding events by severity."""
     plt.style.use("dark_background")
 
+    fig, ax = plt.subplots(figsize=(10, 8))
+    fig.patch.set_facecolor("#2B2B2B")
+
     light_count = 27
     moderate_count = 1
     heavy_count = 0
     severe_count = 8
 
-    fig, ax = plt.subplots(figsize=(6, 6))
-    fig.patch.set_facecolor("#2B2B2B")
-
     sizes = [light_count, moderate_count, heavy_count, severe_count]
-    labels = ['Light', 'Moderate', 'Heavy', 'Severe']
-    colors = ['#F7931E', '#00D9FF', '#4BC0C0', '#FF6B35']
+    labels = ["Light", "Moderate", "Heavy", "Severe"]
+    colors = ["#F7931E", "#00D9FF", "#4BC0C0", "#FF6B35"]
 
-    wedges, texts, autotexts = ax.pie(sizes, labels=labels, colors=colors,
-                                       autopct=lambda pct: f'{pct:.1f}%' if pct > 5 else '',
-                                       startangle=90)
-
-    for text in texts:
-        text.set_color('white')
-        text.set_fontsize(12)
+    wedges, texts, autotexts = ax.pie(
+        sizes,
+        labels=None,
+        colors=colors,
+        autopct=lambda pct: f"{pct:.1f}%" if pct > 5 else "",
+        startangle=90,
+        pctdistance=0.85,
+    )
 
     for autotext in autotexts:
-        autotext.set_color('white')
-        autotext.set_fontsize(11)
+        autotext.set_color("white")
+        autotext.set_fontsize(14)
+        autotext.set_weight("bold")
 
-    ax.set_title("Speeding Events", color="white", pad=10, fontsize=16)
+    ax.set_position([0.1, 0.2, 0.5, 0.6])
+    ax.set_title("Speeding Events", color="white", pad=20, fontsize=18, fontweight="bold")
 
     total = sum(sizes)
-    ax.text(0, -1.3, f"TOTAL: {total}", ha='center', color="white",
-            fontweight='bold', transform=ax.transAxes)
+    fig.text(0.35, 0.1, f"TOTAL: {total}", ha="center", color="white", fontweight="bold", fontsize=16)
 
     legend_labels = [f"{label} - {count}" for label, count in zip(labels, sizes)]
-    ax.legend(wedges, legend_labels, loc="center left", bbox_to_anchor=(1, 0, 0.5, 1),
-              frameon=False, labelcolor='white', fontsize=11)
+    legend = ax.legend(
+        wedges,
+        legend_labels,
+        loc="center left",
+        bbox_to_anchor=(1.2, 0.5),
+        frameon=False,
+        labelcolor="white",
+        fontsize=14,
+        title="Event Type",
+        title_fontsize=16,
+    )
+    legend.get_title().set_color("white")
 
     plt.tight_layout()
-    plt.savefig(out_path, dpi=300, bbox_inches='tight', facecolor="#2B2B2B")
+    plt.savefig(out_path, dpi=400, bbox_inches='tight', facecolor="#2B2B2B")
     plt.close()
     return out_path


### PR DESCRIPTION
## Summary
- standardize matplotlib settings for higher quality charts
- reposition Safety Events legend outside bar chart
- enhance Speeding Events pie chart layout and resolution
- clean up Risk Assessment output and PDF spacing
- reduce margins and spacers for a more compact PDF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630dd63210832cb3be47a0b271ca71