### PR TITLE
Fix pdf builder import

### DIFF
--- a/compliance_snapshot/app/services/pdf_builder.py
+++ b/compliance_snapshot/app/services/pdf_builder.py
@@ -14,6 +14,7 @@ from reportlab.platypus import (
 from reportlab.lib.pagesizes import LETTER
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib import colors
+from reportlab.lib.units import inch
 
 from .report_generator import (
     generate_hos_violations_summary,


### PR DESCRIPTION
## Summary
- fix `inch` import for ReportLab

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686310c585c4832cb4df9c0f552428ca