### PR TITLE
Add dashboard tab with charts

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -245,6 +245,42 @@
         opacity: 0.8;
         transform: translateY(-1px);
     }
+
+    #dashboard-area {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 2rem;
+    }
+
+    #dashboard-grid > div {
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    #dashboard-grid > div:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    }
+
+    @media (max-width: 768px) {
+        #dashboard-grid {
+            grid-template-columns: 1fr !important;
+        }
+    }
+
+    .spinner {
+        display: inline-block;
+        width: 40px;
+        height: 40px;
+        border: 3px solid #f3f3f3;
+        border-top: 3px solid #2a5298;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
   </style>
 </head><body>
   <div class="wizard-header">
@@ -275,6 +311,20 @@
   <form id="finalize-form" data-ticket="{{ ticket }}">
     <!-- DataTable injected here -->
     <div id="table-area"></div>
+
+    <!-- Dashboard container - hidden by default -->
+    <div id="dashboard-area" style="display:none;">
+      <div id="dashboard-grid" style="
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+        gap: 20px;
+        padding: 20px;
+        background: white;
+        border-radius: 12px;
+      ">
+        <!-- Charts will be dynamically inserted here -->
+      </div>
+    </div>
 
     <label style="display:block;margin:.5rem 0">
       Chart&nbsp;type:
@@ -339,6 +389,91 @@ if(trendInput){
   });
 }
 
+async function generateDashboardChart(table, container) {
+  try {
+    // Fetch data for this table
+    const res = await fetch(`/api/${ticket}/query?table=${encodeURIComponent(table)}`);
+    const { columns, rows } = await res.json();
+
+    if (!rows.length) return;
+
+    // Create chart container
+    const chartContainer = document.createElement('div');
+    chartContainer.style.cssText = `
+      background: #f8f9fa;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 15px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    `;
+
+    // Add title
+    const title = document.createElement('h3');
+    title.textContent = TABLE_NAMES[table] || table.replace(/_/g, ' ');
+    title.style.cssText = 'margin: 0 0 10px 0; color: #2a5298; font-size: 16px;';
+    chartContainer.appendChild(title);
+
+    // Create canvas for chart
+    const canvas = document.createElement('canvas');
+    canvas.id = `dashboard-chart-${table}`;
+    canvas.style.cssText = 'max-height: 300px;';
+    chartContainer.appendChild(canvas);
+
+    container.appendChild(chartContainer);
+
+    // Determine chart type based on table
+    const chartType = determineChartType(table);
+
+    // Draw appropriate chart
+    drawDashboardChart(canvas, table, rows, columns, chartType);
+
+  } catch (error) {
+    console.error(`Error generating chart for ${table}:`, error);
+  }
+}
+
+function determineChartType(table) {
+  const chartTypeMap = {
+    'hos': 'bar',
+    'safety_inbox': 'pie',
+    'personnel_conveyance': 'bar',
+    'unassigned_hos': 'bar',
+    'mistdvi': 'pie',
+    'driver_behaviors': 'bar',
+    'driver_safety': 'bar'
+  };
+  return chartTypeMap[table] || 'bar';
+}
+
+function drawDashboardChart(canvas, tableName, rows, cols, chartType) {
+  const ctx = canvas.getContext('2d');
+
+  switch(tableName) {
+    case 'personnel_conveyance':
+      drawPCChartForDashboard(ctx, rows, cols, chartType);
+      break;
+    case 'safety_inbox':
+      drawSafetyChartForDashboard(ctx, rows, cols, chartType);
+      break;
+    case 'unassigned_hos':
+      drawUnassignedChartForDashboard(ctx, rows, cols, chartType);
+      break;
+    case 'driver_behaviors':
+      drawDriverBehaviorsChartForDashboard(ctx, rows, cols, chartType);
+      break;
+    case 'mistdvi':
+      drawMissedDVIRChartForDashboard(ctx, rows, cols, chartType);
+      break;
+    case 'driver_safety':
+    case 'drivers_safety':
+    case 'driver_safety_report':
+      drawDriverSafetyChartForDashboard(ctx, rows, cols, chartType);
+      break;
+    default:
+      drawHOSChartForDashboard(ctx, rows, cols, chartType);
+  }
+}
+
 // ---------- build tab buttons ----------
 async function loadTabs(){
   const msg = document.getElementById('message');
@@ -365,6 +500,14 @@ async function loadTabs(){
     nav.appendChild(btn);
   });
 
+  // After creating all data table tabs, add a Dashboard tab
+  const dashboardBtn = document.createElement('button');
+  dashboardBtn.type = 'button';
+  dashboardBtn.dataset.table = 'dashboard';
+  dashboardBtn.textContent = '📊 Dashboard';
+  dashboardBtn.addEventListener('click', () => openDashboard());
+  nav.appendChild(dashboardBtn);
+
   if(tables.length){
     openTab(tables[0]);
   }else{
@@ -382,10 +525,42 @@ async function loadErrors(){
   div.innerHTML = errs.map(e => `<p>${e}</p>`).join('');
 }
 
+// ---------- open dashboard ----------
+async function openDashboard() {
+  // Hide table area and show dashboard area
+  document.getElementById('table-area').style.display = 'none';
+  document.getElementById('dashboard-area').style.display = 'block';
+  document.getElementById('finalize-form').style.display = 'none';
+
+  // Update active tab styling
+  document.querySelectorAll('nav#tabs button').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.table === 'dashboard');
+  });
+
+  // Clear existing charts
+  const dashboardGrid = document.getElementById('dashboard-grid');
+  dashboardGrid.innerHTML = '<div style="text-align:center; padding:40px;"><div class="spinner"></div><p>Loading charts...</p></div>';
+
+  // Get all available tables
+  const res = await fetch(`/api/${ticket}/tables`);
+  const tables = await res.json();
+
+  dashboardGrid.innerHTML = '';
+  // Generate charts for each table
+  for (const table of tables) {
+    await generateDashboardChart(table, dashboardGrid);
+  }
+}
+
 // ---------- open tab, render table & chart ----------
 async function openTab(table){
   const msg = document.getElementById('message');
   msg.textContent = '';
+
+  // Hide dashboard and show table area
+  document.getElementById('dashboard-area').style.display = 'none';
+  document.getElementById('table-area').style.display = 'block';
+  document.getElementById('finalize-form').style.display = 'block';
 
   // destroy previous table if present
   if(currentDT){

--- a/static/js/additional-charts.js
+++ b/static/js/additional-charts.js
@@ -89,6 +89,35 @@ function drawPCCharts(name, rows, cols, chartType) {
     });
 }
 
+function drawPCChartForDashboard(ctx, rows, cols, chartType) {
+    if (!rows.length) return;
+    const driverIdx = cols.findIndex(c => normalize(c) === 'driver_name');
+    const durationIdx = cols.findIndex(c => normalize(c).startsWith('personal_conveyance'));
+    if (driverIdx === -1 || durationIdx === -1) return;
+    const totals = {};
+    rows.forEach(r => {
+        const d = r[driverIdx];
+        const hrs = parseFloat(r[durationIdx]) || 0;
+        if (d) totals[d] = (totals[d] || 0) + hrs;
+    });
+    const sorted = Object.entries(totals).sort((a,b)=>b[1]-a[1]);
+    if (chartType === 'pie') {
+        const top = sorted.slice(0,10);
+        const others = sorted.slice(10).reduce((sum,[,h])=>sum+h,0);
+        const labels = top.map(([d])=>d);
+        const data = top.map(([,h])=>h);
+        if(others>0){ labels.push('Others'); data.push(others); }
+        const colors = labels.map((_,i)=>`hsl(${i*40},70%,60%)`);
+        new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
+        return;
+    }
+    const top = sorted.slice(0,15);
+    const labels = top.map(([d])=>d);
+    const data = top.map(([,h])=>h);
+    const colors = data.map(h=>h>14?'red':h>10?'orange':'green');
+    new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Hours', data, backgroundColor:colors }] }, options:{ scales:{ y:{ beginAtZero:true } } } });
+}
+
 // Safety Inbox Charts
 function drawSafetyCharts(name, rows, cols, chartType) {
     const canvas = document.getElementById('preview');
@@ -154,6 +183,44 @@ function drawSafetyCharts(name, rows, cols, chartType) {
     });
 }
 
+function drawSafetyChartForDashboard(ctx, rows, cols, chartType) {
+    if (!rows.length) return;
+    const typeIdx = cols.findIndex(c => normalize(c) === 'event_type');
+    const statusIdx = cols.findIndex(c => normalize(c) === 'status');
+    const tagIdx = cols.findIndex(c => normalize(c) === 'driver_tags');
+    if (typeIdx === -1 || tagIdx === -1) return;
+    if (chartType === 'bar' && statusIdx !== -1) {
+        const counts = {};
+        rows.forEach(r => {
+            const type = r[typeIdx];
+            const raw = (r[statusIdx] || '').toLowerCase();
+            const st = raw.includes('dismiss') ? 'Dismissed' : raw.includes('review') ? 'Reviewed' : 'Other';
+            if (!counts[type]) counts[type] = { Dismissed:0, Reviewed:0, Other:0 };
+            counts[type][st] += 1;
+        });
+        const labels = Object.keys(counts);
+        const statuses = ['Dismissed','Reviewed','Other'];
+        const colors = { Dismissed:'#00D9FF', Reviewed:'#FF6B35', Other:'#FF0000' };
+        const datasets = statuses.map(s => ({ label:s, data: labels.map(l=>counts[l][s]), backgroundColor: colors[s] }));
+        new Chart(ctx,{ type:'bar', data:{ labels, datasets }, options:{ scales:{ x:{ stacked:true }, y:{ stacked:true, beginAtZero:true } } } });
+        return;
+    }
+    const regions = ['Great Lakes','Ohio Valley','Southeast','Midwest','Corporate','Gulf Coast'];
+    const counts = {};
+    rows.forEach(r => {
+        const tags = (r[tagIdx] || '').toLowerCase();
+        let found = false;
+        regions.forEach(reg => {
+            if (tags.includes(reg.toLowerCase())) { counts[reg] = (counts[reg]||0)+1; found = true; }
+        });
+        if(!found) counts['Other'] = (counts['Other']||0)+1;
+    });
+    const labels = Object.keys(counts);
+    const data = labels.map(l=>counts[l]);
+    const colors = labels.map((_,i)=>`hsl(${i*40},70%,60%)`);
+    new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
+}
+
 // Unassigned HOS Charts
 function drawUnassignedCharts(name, rows, cols, chartType) {
     const canvas = document.getElementById('preview');
@@ -216,6 +283,49 @@ function drawUnassignedCharts(name, rows, cols, chartType) {
             scales: { y: { beginAtZero: true } }
         }
     });
+}
+
+function drawUnassignedChartForDashboard(ctx, rows, cols, chartType) {
+    if (!rows.length) return;
+    const vehicleIdx = cols.findIndex(c => normalize(c) === 'vehicle');
+    const timeIdx = cols.findIndex(c => normalize(c) === 'unassigned_time');
+    const segIdx = cols.findIndex(c => normalize(c) === 'unassigned_segments');
+    const tagIdx = cols.findIndex(c => normalize(c) === 'tags');
+    if (vehicleIdx === -1 || timeIdx === -1) return;
+    const parseHours = str => {
+        if (typeof str !== 'string') return parseFloat(str) || 0;
+        const m = str.match(/(\d+)h/); const h = m ? parseInt(m[1],10) : 0;
+        const m2 = str.match(/(\d+)m/); const mins = m2 ? parseInt(m2[1],10) : 0;
+        return h + mins/60;
+    };
+    if (chartType === 'pie' && tagIdx !== -1 && segIdx !== -1) {
+        const regions = ['Great Lakes','Ohio Valley','Southeast','Midwest','Corporate','Gulf Coast'];
+        const counts = {};
+        rows.forEach(r => {
+            const tags = (r[tagIdx] || '').toLowerCase();
+            let region = 'Other';
+            regions.forEach(reg => { if (tags.includes(reg.toLowerCase())) region = reg; });
+            const seg = parseInt(r[segIdx],10) || 0;
+            counts[region] = (counts[region] || 0) + seg;
+        });
+        Object.keys(counts).forEach(k => { if (counts[k] === 0) delete counts[k]; });
+        const labels = Object.keys(counts);
+        const data = labels.map(l => counts[l]);
+        const colors = labels.map((_,i)=>`hsl(${i*40},70%,60%)`);
+        new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
+        return;
+    }
+    const totals = {};
+    rows.forEach(r => {
+        const veh = r[vehicleIdx];
+        const hrs = parseHours(r[timeIdx]);
+        if (veh) totals[veh] = (totals[veh] || 0) + hrs;
+    });
+    const sorted = Object.entries(totals).sort((a,b)=>b[1]-a[1]).slice(0,15);
+    const labels = sorted.map(([v]) => v.length > 30 ? v.slice(0,27)+'...' : v);
+    const data = sorted.map(([,h]) => h);
+    const colors = data.map(()=>'#FF6384');
+    new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Hours', data, backgroundColor:colors }] }, options:{ scales:{ y:{ beginAtZero:true } } } });
 }
 
 // Driver Safety Behaviors Charts
@@ -288,6 +398,44 @@ function drawDriverBehaviorsCharts(name, rows, cols, chartType) {
     });
 }
 
+function drawDriverBehaviorsChartForDashboard(ctx, rows, cols, chartType) {
+    if (!rows.length) return;
+    const tagsIdx = cols.findIndex(c => normalize(c) === 'tags');
+    const scoreIdx = cols.findIndex(c => normalize(c).includes('safety_score'));
+    const driverIdx = cols.findIndex(c => normalize(c).includes('driver'));
+    if (scoreIdx === -1 || driverIdx === -1) return;
+    if (chartType === 'pie' && tagsIdx !== -1) {
+        const counts = {};
+        rows.forEach(r => { const reg = extractRegion(r[tagsIdx]); counts[reg] = (counts[reg]||0)+1; });
+        const labels = Object.keys(counts);
+        const data = labels.map(l=>counts[l]);
+        const colors = labels.map((_,i)=>`hsl(${i*40},70%,60%)`);
+        new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
+        return;
+    }
+    if (tagsIdx !== -1) {
+        const regionScores = {};
+        const regionCounts = {};
+        rows.forEach(r => {
+            const reg = extractRegion(r[tagsIdx]);
+            const s = parseFloat(r[scoreIdx]);
+            if(!isNaN(s)) { regionScores[reg] = (regionScores[reg]||0)+s; regionCounts[reg]=(regionCounts[reg]||0)+1; }
+        });
+        if (Object.keys(regionScores).length) {
+            const labels = Object.keys(regionScores);
+            const data = labels.map(l=>regionScores[l]/regionCounts[l]);
+            const colors = data.map(v => v>90?'green':v>=80?'yellow':'red');
+            new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Safety Score', data, backgroundColor:colors }] }, options:{ scales:{ y:{ beginAtZero:true, max:100 } } } });
+            return;
+        }
+    }
+    const scores = rows.map(r => { const sc=parseFloat(r[scoreIdx]); const d=r[driverIdx]; if(!isNaN(sc)&&d) return {d,sc}; }).filter(Boolean).sort((a,b)=>a.sc-b.sc).slice(0,10);
+    if(!scores.length) return;
+    const labels = scores.map(s=>s.d);
+    const data = scores.map(s=>s.sc);
+    new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Safety Score', data, backgroundColor:'#FF6384' }] }, options:{ indexAxis:'y', scales:{ x:{ beginAtZero:true, max:100 } } } });
+}
+
 // Missed DVIR Charts
 function drawMissedDVIRCharts(name, rows, cols, chartType) {
     const canvas = document.getElementById('preview');
@@ -356,6 +504,38 @@ function drawMissedDVIRCharts(name, rows, cols, chartType) {
         data:{ labels, datasets:[{label:'PRE-TRIP',data:preData,backgroundColor:'#3498db'},{label:'POST-TRIP',data:postData,backgroundColor:'#e74c3c'}] },
         options:{ plugins:{ title:{ display:true, text:name } }, scales:{ x:{ stacked:true }, y:{ stacked:true, beginAtZero:true } } }
     });
+}
+
+function drawMissedDVIRChartForDashboard(ctx, rows, cols, chartType) {
+    if (!rows.length) return;
+    const driverIdx = cols.findIndex(c => normalize(c).includes('driver'));
+    const typeIdx = cols.findIndex(c => normalize(c) === 'type');
+    const startIdx = cols.findIndex(c => normalize(c).startsWith('start_time'));
+    if (driverIdx === -1 || typeIdx === -1) return;
+    if (chartType === 'pie') {
+        let pre=0, post=0;
+        rows.forEach(r=>{ const t=(r[typeIdx]||'').toUpperCase(); if(t.includes('PRE')) pre++; else if(t.includes('POST')) post++; });
+        const labels=['PRE-TRIP','POST-TRIP'];
+        const data=[pre,post];
+        new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:['#3498db','#e74c3c'] }] } });
+        return;
+    }
+    if (chartType === 'line' && startIdx !== -1) {
+        const counts={};
+        rows.forEach(r=>{ const d=parseDateTime(r[startIdx]); if(isNaN(d)) return; const day=d.toISOString().split('T')[0]; const t=(r[typeIdx]||'').toUpperCase().includes('PRE')?'PRE-TRIP':'POST-TRIP'; counts[day]=counts[day]||{ 'PRE-TRIP':0,'POST-TRIP':0 }; counts[day][t]+=1; });
+        const labels=Object.keys(counts).sort();
+        const preData=labels.map(l=>counts[l]['PRE-TRIP']);
+        const postData=labels.map(l=>counts[l]['POST-TRIP']);
+        new Chart(ctx,{ type:'line', data:{ labels, datasets:[{label:'PRE-TRIP',data:preData,borderColor:'#3498db',fill:false},{label:'POST-TRIP',data:postData,borderColor:'#e74c3c',fill:false}] }, options:{ scales:{ y:{ beginAtZero:true } } } });
+        return;
+    }
+    const counts={};
+    rows.forEach(r=>{ const d=r[driverIdx]; const t=(r[typeIdx]||'').toUpperCase().includes('PRE')?'PRE-TRIP':'POST-TRIP'; if(!counts[d]) counts[d]={ 'PRE-TRIP':0,'POST-TRIP':0 }; counts[d][t]+=1; });
+    const sorted=Object.entries(counts).sort((a,b)=>(b[1]['PRE-TRIP']+b[1]['POST-TRIP'])-(a[1]['PRE-TRIP']+a[1]['POST-TRIP'])).slice(0,15);
+    const labels=sorted.map(([d])=>d);
+    const preData=sorted.map(([ ,v])=>v['PRE-TRIP']);
+    const postData=sorted.map(([ ,v])=>v['POST-TRIP']);
+    new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{label:'PRE-TRIP',data:preData,backgroundColor:'#3498db'},{label:'POST-TRIP',data:postData,backgroundColor:'#e74c3c'}] }, options:{ scales:{ x:{ stacked:true }, y:{ stacked:true, beginAtZero:true } } } });
 }
 
 // Driver Safety Report Charts
@@ -609,6 +789,48 @@ function drawDriverSafetyCharts(name, rows, cols, chartType) {
     }
 }
 
+function drawDriverSafetyChartForDashboard(ctx, rows, cols, chartType) {
+    const normalize = s => s.toLowerCase().replace(/[^a-z\s]/g,'').replace(/\s+/g,'_').trim();
+    const driverIdx = cols.findIndex(c => { const n = normalize(c); return n==='driver_name' || n.includes('driver_name') || (n.includes('driver') && !n.includes('driver_id')); });
+    const scoreIdx = cols.findIndex(c => normalize(c)==='safety_score' || normalize(c).includes('safety_score'));
+    const distanceIdx = cols.findIndex(c => { const n=normalize(c); return n.includes('total_distance') || n==='total_distance_mi'; });
+    if (chartType === 'bar') {
+        const driverScores=[];
+        rows.forEach(row=>{ const driver=row[driverIdx]; const score=scoreIdx!==-1?parseFloat(row[scoreIdx]):null; const driveTimeStr=row[cols.findIndex(c=>normalize(c).includes('drive_time'))]; if(driver && score!==null && !isNaN(score)){ let driveHours=0; if(driveTimeStr){ driveHours=parseTimeToHours(driveTimeStr); } driverScores.push({driver,score,driveHours}); }});
+        if(driverScores.length===0){ return; }
+        const sorted=driverScores.sort((a,b)=>b.score-a.score).slice(0,10);
+        const colors=sorted.map(d=>d.score>=95?'#4CAF50':d.score>=90?'#8BC34A':d.score>=80?'#FFC107':d.score>=70?'#FF9800':'#F44336');
+        new Chart(ctx,{ type:'bar', data:{ labels:sorted.map(d=>d.driver), datasets:[{ label:'Safety Score', data:sorted.map(d=>d.score), backgroundColor:colors }] }, options:{ indexAxis:'y', scales:{ x:{ beginAtZero:true, max:100 } } } });
+    } else if (chartType === 'pie') {
+        if (driverIdx === -1 || distanceIdx === -1) return;
+        const driverData=[];
+        rows.forEach(row=>{ const driver=row[driverIdx]; const distance=parseFloat(row[distanceIdx])||0; if(driver && distance>0){ driverData.push({driver,distance}); }});
+        if(!driverData.length) return;
+        const top10=driverData.sort((a,b)=>b.distance-a.distance).slice(0,10);
+        new Chart(ctx,{ type:'pie', data:{ labels:top10.map(d=>d.driver), datasets:[{ data:top10.map(d=>d.distance), backgroundColor:['#FF6384','#36A2EB','#FFCE56','#4BC0C0','#9966FF','#FF9F40','#FF6B35','#C9CBCF','#4BC0C0','#F7931E'] }] } });
+    }
+}
+
+function drawHOSChartForDashboard(ctx, rows, cols, chartType) {
+    const normalizeName = s => s.toLowerCase().replace(/[^a-z\s]/g,'').replace(/\s+/g,'_').trim();
+    const vtIdx = cols.findIndex(c => normalizeName(c) === 'violation_type');
+    if (vtIdx === -1) return;
+    const weekIdx = cols.findIndex(c => normalizeName(c) === 'week');
+    if(chartType === 'line' && weekIdx !== -1){
+        const counts={};
+        const weeks=new Set();
+        rows.forEach(r=>{ const vt=r[vtIdx]; const wk=r[weekIdx]; if(vt && wk){ counts[vt]=counts[vt]||{}; counts[vt][wk]=(counts[vt][wk]||0)+1; weeks.add(wk); } });
+        const weekLabels=Array.from(weeks).sort();
+        const palette=['#3366CC','#DC3912','#FF9900','#109618','#990099','#0099C6','#DD4477','#66AA00','#B82E2E','#316395'];
+        const datasets=Object.entries(counts).map(([type,byWeek],i)=>({label:type,data:weekLabels.map(w=>byWeek[w]||0),borderColor:palette[i%palette.length],fill:false}));
+        new Chart(ctx,{type:'line',data:{ labels:weekLabels, datasets }});
+    }else{
+        const counts={};
+        rows.forEach(r=>{ const val=r[vtIdx]; if(val!==null && val!==undefined && String(val).trim().toLowerCase()!=='null'){ counts[val]=(counts[val]||0)+1; }});
+        new Chart(ctx,{ type:chartType, data:{ labels:Object.keys(counts), datasets:[{ label:'count', data:Object.values(counts) }] } });
+    }
+}
+
 // Export functions
 window.drawPCCharts = drawPCCharts;
 window.drawSafetyCharts = drawSafetyCharts;
@@ -616,4 +838,11 @@ window.drawUnassignedCharts = drawUnassignedCharts;
 window.drawDriverBehaviorsCharts = drawDriverBehaviorsCharts;
 window.drawMissedDVIRCharts = drawMissedDVIRCharts;
 window.drawDriverSafetyCharts = drawDriverSafetyCharts;
+window.drawPCChartForDashboard = drawPCChartForDashboard;
+window.drawSafetyChartForDashboard = drawSafetyChartForDashboard;
+window.drawUnassignedChartForDashboard = drawUnassignedChartForDashboard;
+window.drawDriverBehaviorsChartForDashboard = drawDriverBehaviorsChartForDashboard;
+window.drawMissedDVIRChartForDashboard = drawMissedDVIRChartForDashboard;
+window.drawDriverSafetyChartForDashboard = drawDriverSafetyChartForDashboard;
+window.drawHOSChartForDashboard = drawHOSChartForDashboard;
 


### PR DESCRIPTION
## Summary
- create dashboard grid area and loading spinner
- add Dashboard button to tab nav
- implement dashboard loading logic
- render charts for each report type on the dashboard
- update chart library with dashboard-specific functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b8f7e4c8832c997927cad02de0af