### PR TITLE
Simplify dashboard chart generation

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -397,106 +397,345 @@ if(trendInput){
 }
 
   async function generateDashboardChart(table, container) {
-    console.log(`Generating dashboard chart for ${table}...`);
-
     try {
       // Fetch data for this table
       const res = await fetch(`/api/${ticket}/query?table=${encodeURIComponent(table)}`);
       const { columns, rows } = await res.json();
-      console.log(`Fetched ${rows.length} rows for ${table}`);
 
-      if (!rows.length) {
-        console.log(`No data for ${table}, skipping`);
-        return;
-      }
+      if (!rows.length) return;
 
       // Create chart container
       const chartContainer = document.createElement('div');
       chartContainer.style.cssText = `
-        background: #f8f9fa;
+        background: white;
         border: 1px solid #e2e8f0;
         border-radius: 8px;
-        padding: 15px;
+        padding: 20px;
         box-shadow: 0 2px 4px rgba(0,0,0,0.05);
       `;
 
       // Add title
       const title = document.createElement('h3');
       title.textContent = TABLE_NAMES[table] || table.replace(/_/g, ' ');
-      title.style.cssText = 'margin: 0 0 10px 0; color: #2a5298; font-size: 16px;';
+      title.style.cssText = 'margin: 0 0 15px 0; color: #2a5298; font-size: 18px; font-weight: 600;';
       chartContainer.appendChild(title);
 
       // Create canvas for chart
       const canvas = document.createElement('canvas');
-      canvas.id = `dashboard-chart-${table}`;
-      canvas.style.cssText = 'max-height: 300px;';
+      canvas.style.cssText = 'max-height: 300px; width: 100%;';
       chartContainer.appendChild(canvas);
-
       container.appendChild(chartContainer);
 
-      // Determine chart type based on table
-      const chartType = determineChartType(table);
-
-      // Draw appropriate chart - GET CONTEXT HERE
       const ctx = canvas.getContext('2d');
-      console.log(`Drawing ${chartType} chart for ${table}`);
-      drawDashboardChart(ctx, table, rows, columns, chartType);
+      const normalize = s => s.toLowerCase().replace(/[^a-z\s]/g, '').replace(/\s+/g, '_').trim();
+
+      // Create charts based on table type
+      switch(table) {
+        case 'hos':
+          // HOS Violations - Stacked Bar Chart by Violation Type
+          const vtIdx = columns.findIndex(c => normalize(c) === 'violation_type');
+          const tagIdx = columns.findIndex(c => normalize(c) === 'tags');
+
+          if (vtIdx !== -1) {
+            const violationCounts = {};
+            rows.forEach(row => {
+              const vt = row[vtIdx];
+              if (vt) violationCounts[vt] = (violationCounts[vt] || 0) + 1;
+            });
+
+            new Chart(ctx, {
+              type: 'bar',
+              data: {
+                labels: Object.keys(violationCounts),
+                datasets: [{
+                  label: 'Violation Count',
+                  data: Object.values(violationCounts),
+                  backgroundColor: ['#FF6B35', '#F7931E', '#39FF14', '#00D9FF', '#FF0000']
+                }]
+              },
+              options: {
+                responsive: true,
+                plugins: {
+                  title: { display: true, text: 'HOS Violations by Type' }
+                }
+              }
+            });
+          }
+          break;
+
+        case 'safety_inbox':
+          // Safety Inbox - Pie Chart by Event Type
+          const eventIdx = columns.findIndex(c => normalize(c) === 'event_type');
+
+          if (eventIdx !== -1) {
+            const eventCounts = {};
+            rows.forEach(row => {
+              const event = row[eventIdx];
+              if (event) eventCounts[event] = (eventCounts[event] || 0) + 1;
+            });
+
+            new Chart(ctx, {
+              type: 'pie',
+              data: {
+                labels: Object.keys(eventCounts).slice(0, 6),
+                datasets: [{
+                  data: Object.values(eventCounts).slice(0, 6),
+                  backgroundColor: ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40']
+                }]
+              },
+              options: {
+                responsive: true,
+                plugins: {
+                  title: { display: true, text: 'Safety Events Distribution' }
+                }
+              }
+            });
+          }
+          break;
+
+        case 'personnel_conveyance':
+          // PC Usage - Bar Chart of Top Users
+          const driverIdx = columns.findIndex(c => normalize(c).includes('driver'));
+          const durationIdx = columns.findIndex(c => normalize(c).includes('personal_conveyance') || normalize(c).includes('duration'));
+
+          if (driverIdx !== -1 && durationIdx !== -1) {
+            const driverTotals = {};
+            rows.forEach(row => {
+              const driver = row[driverIdx];
+              const duration = parseFloat(row[durationIdx]) || 0;
+              if (driver) driverTotals[driver] = (driverTotals[driver] || 0) + duration;
+            });
+
+            const sorted = Object.entries(driverTotals)
+              .sort((a, b) => b[1] - a[1])
+              .slice(0, 10);
+
+            new Chart(ctx, {
+              type: 'bar',
+              data: {
+                labels: sorted.map(([driver]) => driver),
+                datasets: [{
+                  label: 'PC Hours',
+                  data: sorted.map(([, hours]) => hours),
+                  backgroundColor: sorted.map(([, hours]) => hours > 14 ? '#FF6384' : hours > 10 ? '#FFA500' : '#4CAF50')
+                }]
+              },
+              options: {
+                responsive: true,
+                plugins: {
+                  title: { display: true, text: 'Top 10 PC Users' }
+                },
+                scales: {
+                  y: { beginAtZero: true }
+                }
+              }
+            });
+          }
+          break;
+
+        case 'unassigned_hos':
+          // Unassigned HOS - Bar Chart by Vehicle
+          const vehicleIdx = columns.findIndex(c => normalize(c) === 'vehicle');
+          const segmentsIdx = columns.findIndex(c => normalize(c).includes('unassigned_segments'));
+
+          if (vehicleIdx !== -1 && segmentsIdx !== -1) {
+            const vehicleSegments = {};
+            rows.forEach(row => {
+              const vehicle = row[vehicleIdx];
+              const segments = parseInt(row[segmentsIdx]) || 0;
+              if (vehicle) vehicleSegments[vehicle] = (vehicleSegments[vehicle] || 0) + segments;
+            });
+
+            const sorted = Object.entries(vehicleSegments)
+              .sort((a, b) => b[1] - a[1])
+              .slice(0, 8);
+
+            new Chart(ctx, {
+              type: 'horizontalBar',
+              data: {
+                labels: sorted.map(([vehicle]) => vehicle.length > 30 ? vehicle.slice(0, 27) + '...' : vehicle),
+                datasets: [{
+                  label: 'Unassigned Segments',
+                  data: sorted.map(([, segments]) => segments),
+                  backgroundColor: '#FF6B35'
+                }]
+              },
+              options: {
+                responsive: true,
+                plugins: {
+                  title: { display: true, text: 'Unassigned Segments by Vehicle' }
+                },
+                scales: {
+                  x: { beginAtZero: true }
+                }
+              }
+            });
+          }
+          break;
+
+        case 'mistdvi':
+          // Missed DVIR - Pie Chart Pre vs Post
+          const typeIdx = columns.findIndex(c => normalize(c) === 'type');
+
+          if (typeIdx !== -1) {
+            let preCount = 0, postCount = 0;
+            rows.forEach(row => {
+              const type = (row[typeIdx] || '').toUpperCase();
+              if (type.includes('PRE')) preCount++;
+              else if (type.includes('POST')) postCount++;
+            });
+
+            new Chart(ctx, {
+              type: 'doughnut',
+              data: {
+                labels: ['Pre-Trip', 'Post-Trip'],
+                datasets: [{
+                  data: [preCount, postCount],
+                  backgroundColor: ['#3498db', '#e74c3c']
+                }]
+              },
+              options: {
+                responsive: true,
+                plugins: {
+                  title: { display: true, text: 'Missed DVIRs by Type' }
+                }
+              }
+            });
+          }
+          break;
+
+        case 'driver_behaviors':
+          // Driver Behaviors - Safety Score by Region
+          const scoreIdx = columns.findIndex(c => normalize(c).includes('safety_score'));
+          const regionIdx = columns.findIndex(c => normalize(c) === 'tags');
+
+          if (scoreIdx !== -1 && regionIdx !== -1) {
+            const regionScores = {};
+            const regionCounts = {};
+
+            rows.forEach(row => {
+              const score = parseFloat(row[scoreIdx]);
+              const tags = (row[regionIdx] || '').toLowerCase();
+              let region = 'Other';
+
+              if (tags.includes('great lakes') || tags.includes('gl')) region = 'Great Lakes';
+              else if (tags.includes('ohio valley') || tags.includes('ov')) region = 'Ohio Valley';
+              else if (tags.includes('southeast') || tags.includes('se')) region = 'Southeast';
+              else if (tags.includes('midwest') || tags.includes('mw')) region = 'Midwest';
+
+              if (!isNaN(score)) {
+                regionScores[region] = (regionScores[region] || 0) + score;
+                regionCounts[region] = (regionCounts[region] || 0) + 1;
+              }
+            });
+
+            const avgScores = Object.entries(regionScores).map(([region, total]) => ({
+              region,
+              avg: total / regionCounts[region]
+            }));
+
+            new Chart(ctx, {
+              type: 'bar',
+              data: {
+                labels: avgScores.map(d => d.region),
+                datasets: [{
+                  label: 'Average Safety Score',
+                  data: avgScores.map(d => d.avg),
+                  backgroundColor: avgScores.map(d => d.avg > 90 ? '#4CAF50' : d.avg > 80 ? '#FFC107' : '#F44336')
+                }]
+              },
+              options: {
+                responsive: true,
+                plugins: {
+                  title: { display: true, text: 'Average Safety Score by Region' }
+                },
+                scales: {
+                  y: { beginAtZero: true, max: 100 }
+                }
+              }
+            });
+          }
+          break;
+
+        case 'driver_safety':
+        case 'drivers_safety':
+          // Driver Safety - Top 10 Drivers by Safety Score
+          const driverNameIdx = columns.findIndex(c => normalize(c).includes('driver_name') || (normalize(c).includes('driver') && !normalize(c).includes('driver_id')));
+          const safetyScoreIdx = columns.findIndex(c => normalize(c).includes('safety_score'));
+
+          if (driverNameIdx !== -1 && safetyScoreIdx !== -1) {
+            const driverScores = [];
+            rows.forEach(row => {
+              const driver = row[driverNameIdx];
+              const score = parseFloat(row[safetyScoreIdx]);
+              if (driver && !isNaN(score)) {
+                driverScores.push({ driver, score });
+              }
+            });
+
+            const top10 = driverScores.sort((a, b) => b.score - a.score).slice(0, 10);
+
+            new Chart(ctx, {
+              type: 'horizontalBar',
+              data: {
+                labels: top10.map(d => d.driver),
+                datasets: [{
+                  label: 'Safety Score',
+                  data: top10.map(d => d.score),
+                  backgroundColor: top10.map(d => d.score >= 95 ? '#4CAF50' : d.score >= 90 ? '#8BC34A' : '#FFC107')
+                }]
+              },
+              options: {
+                responsive: true,
+                plugins: {
+                  title: { display: true, text: 'Top 10 Drivers by Safety Score' }
+                },
+                scales: {
+                  x: { beginAtZero: true, max: 100 }
+                }
+              }
+            });
+          }
+          break;
+
+        default:
+          // Generic bar chart for unknown tables
+          const firstCol = columns[0];
+          const counts = {};
+          rows.forEach(row => {
+            const val = row[0];
+            if (val) counts[val] = (counts[val] || 0) + 1;
+          });
+
+          new Chart(ctx, {
+            type: 'bar',
+            data: {
+              labels: Object.keys(counts).slice(0, 10),
+              datasets: [{
+                label: 'Count',
+                data: Object.values(counts).slice(0, 10),
+                backgroundColor: '#2a5298'
+              }]
+            },
+            options: {
+              responsive: true,
+              plugins: {
+                title: { display: true, text: `${TABLE_NAMES[table] || table} Overview` }
+              }
+            }
+          });
+      }
 
     } catch (error) {
       console.error(`Error generating chart for ${table}:`, error);
 
       const errorDiv = document.createElement('div');
-      errorDiv.style.cssText = 'padding: 20px; background: #fee; border: 1px solid #fcc; border-radius: 8px; color: #c00;';
+      errorDiv.style.cssText = 'padding: 20px; background: #fee; border: 1px solid #fcc; border-radius: 8px; color: #c00; margin-bottom: 20px;';
       errorDiv.textContent = `Failed to load ${TABLE_NAMES[table] || table} chart: ${error.message}`;
       container.appendChild(errorDiv);
     }
   }
 
-function determineChartType(table) {
-  const chartTypeMap = {
-    'hos': 'bar',
-    'safety_inbox': 'pie',
-    'personnel_conveyance': 'bar',
-    'unassigned_hos': 'bar',
-    'mistdvi': 'pie',
-    'driver_behaviors': 'bar',
-    'driver_safety': 'bar'
-  };
-  return chartTypeMap[table] || 'bar';
-}
-
-function drawDashboardChart(ctx, tableName, rows, cols, chartType) {
-  console.log(`drawDashboardChart called for ${tableName} with ${rows.length} rows`);
-  try {
-    switch(tableName) {
-      case 'personnel_conveyance':
-        window.drawPCChartForDashboard(ctx, rows, cols, chartType);
-        break;
-      case 'safety_inbox':
-        window.drawSafetyChartForDashboard(ctx, rows, cols, chartType);
-        break;
-      case 'unassigned_hos':
-        window.drawUnassignedChartForDashboard(ctx, rows, cols, chartType);
-        break;
-      case 'driver_behaviors':
-        window.drawDriverBehaviorsChartForDashboard(ctx, rows, cols, chartType);
-        break;
-      case 'mistdvi':
-        window.drawMissedDVIRChartForDashboard(ctx, rows, cols, chartType);
-        break;
-      case 'driver_safety':
-      case 'drivers_safety':
-      case 'driver_safety_report':
-        window.drawDriverSafetyChartForDashboard(ctx, rows, cols, chartType);
-        break;
-      default:
-        window.drawHOSChartForDashboard(ctx, rows, cols, chartType);
-    }
-  } catch (error) {
-    console.error(`Error in drawDashboardChart for ${tableName}:`, error);
-    throw error;
-  }
-}
 
 // ---------- build tab buttons ----------
 async function loadTabs(){
@@ -551,15 +790,6 @@ async function loadErrors(){
 
 // ---------- open dashboard ----------
 async function openDashboard() {
-  console.log('Opening dashboard...');
-
-  // Check if chart functions are loaded
-  if (!window.drawHOSChartForDashboard) {
-    console.error('Chart functions not loaded! Check if additional-charts.js is included properly');
-    alert('Chart functions not loaded. Please refresh the page.');
-    return;
-  }
-
   // Hide table area and show dashboard area
   document.getElementById('table-area').style.display = 'none';
   document.getElementById('dashboard-area').style.display = 'block';
@@ -577,17 +807,18 @@ async function openDashboard() {
   // Get all available tables
   const res = await fetch(`/api/${ticket}/tables`);
   const tables = await res.json();
-  console.log('Available tables:', tables);
 
+  // Clear loading message
   dashboardGrid.innerHTML = '';
+  
   // Generate charts for each table
   for (const table of tables) {
-    console.log('Generating chart for table:', table);
-    try {
-      await generateDashboardChart(table, dashboardGrid);
-    } catch (error) {
-      console.error(`Failed to generate chart for ${table}:`, error);
-    }
+    await generateDashboardChart(table, dashboardGrid);
+  }
+
+  // If no charts were generated
+  if (dashboardGrid.children.length === 0) {
+    dashboardGrid.innerHTML = '<div style="text-align:center; padding:40px; color:#666;">No data available to display charts.</div>';
   }
 }
 


### PR DESCRIPTION
## Summary
- embed new chart creation logic directly in the Dashboard tab
- streamline the Dashboard view without helper chart functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687534960b48832cad990e9c0b53909a