### PR TITLE
Fix dashboard charts with Chart.js 3

### DIFF
--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -551,7 +551,7 @@ if(trendInput){
               .slice(0, 8);
 
             new Chart(ctx, {
-              type: 'horizontalBar',
+              type: 'bar',
               data: {
                 labels: sorted.map(([vehicle]) => vehicle.length > 30 ? vehicle.slice(0, 27) + '...' : vehicle),
                 datasets: [{
@@ -561,6 +561,7 @@ if(trendInput){
                 }]
               },
               options: {
+                indexAxis: 'y',
                 responsive: true,
                 plugins: {
                   title: { display: true, text: 'Unassigned Segments by Vehicle' }
@@ -676,7 +677,7 @@ if(trendInput){
             const top10 = driverScores.sort((a, b) => b.score - a.score).slice(0, 10);
 
             new Chart(ctx, {
-              type: 'horizontalBar',
+              type: 'bar',
               data: {
                 labels: top10.map(d => d.driver),
                 datasets: [{
@@ -686,6 +687,7 @@ if(trendInput){
                 }]
               },
               options: {
+                indexAxis: 'y',
                 responsive: true,
                 plugins: {
                   title: { display: true, text: 'Top 10 Drivers by Safety Score' }


### PR DESCRIPTION
## Summary
- ensure horizontal bar charts work with Chart.js 3 by switching to `type: 'bar'` + `indexAxis: 'y'`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753a8bc85c832c9f0a8a1556ebf93f