### PR TITLE
Add dashboard summaries and tests

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -109,7 +109,51 @@ async def get_dashboard_data(ticket: str):
                     'data': summary,
                     'title': 'Safety Events Distribution'
                 }
-            # additional table summaries can be added here
+            elif table == 'personnel_conveyance':
+                col = 'driver_name' if 'driver_name' in df.columns else df.columns[0]
+                summary = df[col].value_counts().head(5).to_dict()
+                dashboard_data[table] = {
+                    'type': 'bar',
+                    'data': summary,
+                    'title': 'Top Personal Conveyance Drivers'
+                }
+            elif table == 'unassigned_hos':
+                col = 'vehicle' if 'vehicle' in df.columns else df.columns[0]
+                summary = df[col].value_counts().head(5).to_dict()
+                dashboard_data[table] = {
+                    'type': 'bar',
+                    'data': summary,
+                    'title': 'Unassigned HOS by Vehicle'
+                }
+            elif table == 'mistdvi':
+                col = 'type' if 'type' in df.columns else df.columns[0]
+                summary = df[col].value_counts().head(5).to_dict()
+                dashboard_data[table] = {
+                    'type': 'pie',
+                    'data': summary,
+                    'title': 'Missed DVIR Types'
+                }
+            elif table == 'driver_behaviors':
+                col = 'driver_name' if 'driver_name' in df.columns else df.columns[0]
+                summary = df[col].value_counts().head(5).to_dict()
+                dashboard_data[table] = {
+                    'type': 'bar',
+                    'data': summary,
+                    'title': 'Driver Behaviors by Driver'
+                }
+            elif table == 'driver_safety':
+                if 'driver_id' in df.columns:
+                    col = 'driver_id'
+                elif 'driver_name' in df.columns:
+                    col = 'driver_name'
+                else:
+                    col = df.columns[0]
+                summary = df[col].value_counts().head(5).to_dict()
+                dashboard_data[table] = {
+                    'type': 'bar',
+                    'data': summary,
+                    'title': 'Driver Safety Incidents'
+                }
 
         con.close()
         return JSONResponse(dashboard_data)

--- a/compliance_snapshot/tests/test_dashboard.py
+++ b/compliance_snapshot/tests/test_dashboard.py
@@ -1,0 +1,56 @@
+import os
+import sqlite3
+import pandas as pd
+from pathlib import Path as _P
+import sys
+
+ROOT = _P(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("OPEN_API_KEY", "test")
+from app.main import app
+
+import uuid
+
+
+def _create_db(tmp_path: _P) -> str:
+    ticket = uuid.uuid4().hex
+    ticket_path = _P(f"/tmp/{ticket}")
+    ticket_path.mkdir(parents=True, exist_ok=True)
+    db_path = ticket_path / "snapshot.db"
+    con = sqlite3.connect(db_path)
+
+    pd.DataFrame({"driver_name": ["A", "B", "A"]}).to_sql(
+        "personnel_conveyance", con, index=False
+    )
+    pd.DataFrame({"vehicle": ["V1", "V2", "V1"]}).to_sql(
+        "unassigned_hos", con, index=False
+    )
+    pd.DataFrame({"type": ["pre", "post", "pre"]}).to_sql("mistdvi", con, index=False)
+    pd.DataFrame({"driver_name": ["A", "B", "A"]}).to_sql(
+        "driver_behaviors", con, index=False
+    )
+    pd.DataFrame({"driver_id": ["D1", "D2", "D1"]}).to_sql(
+        "driver_safety", con, index=False
+    )
+    con.close()
+    return ticket
+
+def test_dashboard_data_keys(tmp_path):
+    ticket = _create_db(tmp_path)
+    client = TestClient(app)
+    resp = client.get(f"/api/{ticket}/dashboard-data")
+    assert resp.status_code == 200
+    data = resp.json()
+    expected = {
+        "personnel_conveyance",
+        "unassigned_hos",
+        "mistdvi",
+        "driver_behaviors",
+        "driver_safety",
+    }
+    assert expected.issubset(data.keys())
+    for key in expected:
+        assert set(data[key].keys()) == {"type", "data", "title"}


### PR DESCRIPTION
## Summary
- implement dashboard summaries for personnel, unassigned, mistdvi, behavior and safety tables
- test dashboard API returns expected keys

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756259d520832c86dd6daddc755bb8