### PR TITLE
Fix dashboard chart returns and canvas handling

### DIFF
--- a/compliance_snapshot/app/routers/wizard.py
+++ b/compliance_snapshot/app/routers/wizard.py
@@ -13,7 +13,7 @@ from ..services.docx_builder import pdf_to_docx
 from ..core.utils import file_response
 
 router = APIRouter()
-templates = Jinja2Templates(directory="compliance_snapshot/app/templates")
+templates = Jinja2Templates(directory="app/templates")
 
 
 def _db(ticket: str) -> Path:

--- a/compliance_snapshot/app/templates/wizard.html
+++ b/compliance_snapshot/app/templates/wizard.html
@@ -468,6 +468,9 @@ async function loadErrors(){
 async function openDashboard() {
   console.log('=== DASHBOARD OPENED ===');
   console.log('Chart.js loaded?', typeof Chart !== 'undefined');
+  Chart.defaults.responsive = true;
+  Chart.defaults.maintainAspectRatio = false;
+  Chart.defaults.plugins.legend.display = false;
   document.getElementById('table-area').style.display = 'none';
   document.getElementById('dashboard-area').style.display = 'block';
   document.getElementById('finalize-form').style.display = 'none';
@@ -544,21 +547,19 @@ async function openDashboard() {
 
       // Let the browser calculate dimensions
       setTimeout(() => {
-          // Force canvas to have proper dimensions
-          canvas.width = container.offsetWidth || 350;
-          canvas.height = 250;
-
           const ctx = canvas.getContext('2d');
-
           const draw = chartMap[type];
           try {
             if (draw) {
-              console.log(`Drawing ${type} with canvas size: ${canvas.width}x${canvas.height}`);
+              console.log(`Drawing ${type}...`);
               const chartInstance = draw(ctx, rows, columns, chartTypeDefaults[type] || 'bar');
               console.log(`${type} chart instance:`, chartInstance);
-              if (!chartInstance) {
-                console.error(`No chart instance returned for ${type}`);
+              if (chartInstance && chartInstance.canvas) {
+                chartInstance.resize(350, 250);
+                console.log(`Resized ${type} chart to 350x250`);
               }
+              if (!window.dashboardCharts) window.dashboardCharts = {};
+              window.dashboardCharts[type] = chartInstance;
             }
           } catch (error) {
             console.error(`Error drawing ${type} chart:`, error);

--- a/static/js/additional-charts.js
+++ b/static/js/additional-charts.js
@@ -113,18 +113,16 @@ function drawPCChartForDashboard(ctx, rows, cols, chartType) {
         if(others>0){ labels.push('Others'); data.push(others); }
         const colors = labels.map((_,i)=>`hsl(${i*40},70%,60%)`);
         console.log('[PC Dashboard] Creating pie chart with data:', data);
-        const chart = new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
-        console.log('[PC Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[PC Dashboard] Chart created');
+        return new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
     }
     const top = sorted.slice(0,15);
     const labels = top.map(([d])=>d);
     const data = top.map(([,h])=>h);
     const colors = data.map(h=>h>14?'red':h>10?'orange':'green');
     console.log('[PC Dashboard] Creating bar chart with data:', data);
-    const chart = new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Hours', data, backgroundColor:colors }] }, options:{ scales:{ y:{ beginAtZero:true } } } });
-    console.log('[PC Dashboard] Chart created:', chart);
-    return chart;
+    console.log('[PC Dashboard] Chart created');
+    return new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Hours', data, backgroundColor:colors }] }, options:{ scales:{ y:{ beginAtZero:true } } } });
 }
 
 // Safety Inbox Charts
@@ -216,9 +214,8 @@ function drawSafetyChartForDashboard(ctx, rows, cols, chartType) {
         const colors = { Dismissed:'#00D9FF', Reviewed:'#FF6B35', Other:'#FF0000' };
         const datasets = statuses.map(s => ({ label:s, data: labels.map(l=>counts[l][s]), backgroundColor: colors[s] }));
         console.log('[Safety Dashboard] Creating bar chart with data:', counts);
-        const chart = new Chart(ctx,{ type:'bar', data:{ labels, datasets }, options:{ scales:{ x:{ stacked:true }, y:{ stacked:true, beginAtZero:true } } } });
-        console.log('[Safety Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[Safety Dashboard] Chart created');
+        return new Chart(ctx,{ type:'bar', data:{ labels, datasets }, options:{ scales:{ x:{ stacked:true }, y:{ stacked:true, beginAtZero:true } } } });
     }
     const regions = ['Great Lakes','Ohio Valley','Southeast','Midwest','Corporate','Gulf Coast'];
     const counts = {};
@@ -234,9 +231,8 @@ function drawSafetyChartForDashboard(ctx, rows, cols, chartType) {
     const data = labels.map(l=>counts[l]);
     const colors = labels.map((_,i)=>`hsl(${i*40},70%,60%)`);
     console.log('[Safety Dashboard] Creating pie chart with data:', counts);
-    const chart = new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
-    console.log('[Safety Dashboard] Chart created:', chart);
-    return chart;
+    console.log('[Safety Dashboard] Chart created');
+    return new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
 }
 
 // Unassigned HOS Charts
@@ -335,9 +331,8 @@ function drawUnassignedChartForDashboard(ctx, rows, cols, chartType) {
         const data = labels.map(l => counts[l]);
         const colors = labels.map((_,i)=>`hsl(${i*40},70%,60%)`);
         console.log('[Unassigned Dashboard] Creating pie chart with data:', counts);
-        const chart = new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
-        console.log('[Unassigned Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[Unassigned Dashboard] Chart created');
+        return new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
     }
     const totals = {};
     rows.forEach(r => {
@@ -350,9 +345,8 @@ function drawUnassignedChartForDashboard(ctx, rows, cols, chartType) {
     const data = sorted.map(([,h]) => h);
     const colors = data.map(()=>'#FF6384');
     console.log('[Unassigned Dashboard] Creating bar chart with data:', data);
-    const chart = new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Hours', data, backgroundColor:colors }] }, options:{ scales:{ y:{ beginAtZero:true } } } });
-    console.log('[Unassigned Dashboard] Chart created:', chart);
-    return chart;
+    console.log('[Unassigned Dashboard] Chart created');
+    return new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Hours', data, backgroundColor:colors }] }, options:{ scales:{ y:{ beginAtZero:true } } } });
 }
 
 // Driver Safety Behaviors Charts
@@ -443,9 +437,8 @@ function drawDriverBehaviorsChartForDashboard(ctx, rows, cols, chartType) {
         const data = labels.map(l=>counts[l]);
         const colors = labels.map((_,i)=>`hsl(${i*40},70%,60%)`);
         console.log('[Behaviors Dashboard] Creating pie chart with data:', counts);
-        const chart = new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
-        console.log('[Behaviors Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[Behaviors Dashboard] Chart created');
+        return new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:colors }] } });
     }
     if (tagsIdx !== -1) {
         const regionScores = {};
@@ -460,9 +453,8 @@ function drawDriverBehaviorsChartForDashboard(ctx, rows, cols, chartType) {
             const data = labels.map(l=>regionScores[l]/regionCounts[l]);
             const colors = data.map(v => v>90?'green':v>=80?'yellow':'red');
             console.log('[Behaviors Dashboard] Creating bar chart with regional scores:', data);
-            const chart = new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Safety Score', data, backgroundColor:colors }] }, options:{ scales:{ y:{ beginAtZero:true, max:100 } } } });
-            console.log('[Behaviors Dashboard] Chart created:', chart);
-            return chart;
+            console.log('[Behaviors Dashboard] Chart created');
+            return new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Safety Score', data, backgroundColor:colors }] }, options:{ scales:{ y:{ beginAtZero:true, max:100 } } } });
         }
     }
     const scores = rows.map(r => { const sc=parseFloat(r[scoreIdx]); const d=r[driverIdx]; if(!isNaN(sc)&&d) return {d,sc}; }).filter(Boolean).sort((a,b)=>a.sc-b.sc).slice(0,10);
@@ -470,9 +462,8 @@ function drawDriverBehaviorsChartForDashboard(ctx, rows, cols, chartType) {
     const labels = scores.map(s=>s.d);
     const data = scores.map(s=>s.sc);
     console.log('[Behaviors Dashboard] Creating bar chart with data:', data);
-    const chart = new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Safety Score', data, backgroundColor:'#FF6384' }] }, options:{ indexAxis:'y', scales:{ x:{ beginAtZero:true, max:100 } } } });
-    console.log('[Behaviors Dashboard] Chart created:', chart);
-    return chart;
+    console.log('[Behaviors Dashboard] Chart created');
+    return new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{ label:'Safety Score', data, backgroundColor:'#FF6384' }] }, options:{ indexAxis:'y', scales:{ x:{ beginAtZero:true, max:100 } } } });
 }
 
 // Missed DVIR Charts
@@ -562,9 +553,8 @@ function drawMissedDVIRChartForDashboard(ctx, rows, cols, chartType) {
         const labels=['PRE-TRIP','POST-TRIP'];
         const data=[pre,post];
         console.log('[DVIR Dashboard] Creating pie chart with data:', {pre,post});
-        const chart = new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:['#3498db','#e74c3c'] }] } });
-        console.log('[DVIR Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[DVIR Dashboard] Chart created');
+        return new Chart(ctx,{ type:'pie', data:{ labels, datasets:[{ data, backgroundColor:['#3498db','#e74c3c'] }] } });
     }
     if (chartType === 'line' && startIdx !== -1) {
         const counts={};
@@ -573,9 +563,8 @@ function drawMissedDVIRChartForDashboard(ctx, rows, cols, chartType) {
         const preData=labels.map(l=>counts[l]['PRE-TRIP']);
         const postData=labels.map(l=>counts[l]['POST-TRIP']);
         console.log('[DVIR Dashboard] Creating line chart with data:', counts);
-        const chart = new Chart(ctx,{ type:'line', data:{ labels, datasets:[{label:'PRE-TRIP',data:preData,borderColor:'#3498db',fill:false},{label:'POST-TRIP',data:postData,borderColor:'#e74c3c',fill:false}] }, options:{ scales:{ y:{ beginAtZero:true } } } });
-        console.log('[DVIR Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[DVIR Dashboard] Chart created');
+        return new Chart(ctx,{ type:'line', data:{ labels, datasets:[{label:'PRE-TRIP',data:preData,borderColor:'#3498db',fill:false},{label:'POST-TRIP',data:postData,borderColor:'#e74c3c',fill:false}] }, options:{ scales:{ y:{ beginAtZero:true } } } });
     }
     const counts={};
     rows.forEach(r=>{ const d=r[driverIdx]; const t=(r[typeIdx]||'').toUpperCase().includes('PRE')?'PRE-TRIP':'POST-TRIP'; if(!counts[d]) counts[d]={ 'PRE-TRIP':0,'POST-TRIP':0 }; counts[d][t]+=1; });
@@ -584,9 +573,8 @@ function drawMissedDVIRChartForDashboard(ctx, rows, cols, chartType) {
     const preData=sorted.map(([ ,v])=>v['PRE-TRIP']);
     const postData=sorted.map(([ ,v])=>v['POST-TRIP']);
     console.log('[DVIR Dashboard] Creating bar chart with data:', counts);
-    const chart = new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{label:'PRE-TRIP',data:preData,backgroundColor:'#3498db'},{label:'POST-TRIP',data:postData,backgroundColor:'#e74c3c'}] }, options:{ scales:{ x:{ stacked:true }, y:{ stacked:true, beginAtZero:true } } } });
-    console.log('[DVIR Dashboard] Chart created:', chart);
-    return chart;
+    console.log('[DVIR Dashboard] Chart created');
+    return new Chart(ctx,{ type:'bar', data:{ labels, datasets:[{label:'PRE-TRIP',data:preData,backgroundColor:'#3498db'},{label:'POST-TRIP',data:postData,backgroundColor:'#e74c3c'}] }, options:{ scales:{ x:{ stacked:true }, y:{ stacked:true, beginAtZero:true } } } });
 }
 
 // Driver Safety Report Charts
@@ -854,9 +842,8 @@ function drawDriverSafetyChartForDashboard(ctx, rows, cols, chartType) {
         const sorted=driverScores.sort((a,b)=>b.score-a.score).slice(0,10);
         const colors=sorted.map(d=>d.score>=95?'#4CAF50':d.score>=90?'#8BC34A':d.score>=80?'#FFC107':d.score>=70?'#FF9800':'#F44336');
         console.log('[Driver Safety Dashboard] Creating bar chart with data:', sorted);
-        const chart = new Chart(ctx,{ type:'bar', data:{ labels:sorted.map(d=>d.driver), datasets:[{ label:'Safety Score', data:sorted.map(d=>d.score), backgroundColor:colors }] }, options:{ indexAxis:'y', scales:{ x:{ beginAtZero:true, max:100 } } } });
-        console.log('[Driver Safety Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[Driver Safety Dashboard] Chart created');
+        return new Chart(ctx,{ type:'bar', data:{ labels:sorted.map(d=>d.driver), datasets:[{ label:'Safety Score', data:sorted.map(d=>d.score), backgroundColor:colors }] }, options:{ indexAxis:'y', scales:{ x:{ beginAtZero:true, max:100 } } } });
     } else if (chartType === 'pie') {
         if (driverIdx === -1 || distanceIdx === -1) return;
         const driverData=[];
@@ -864,9 +851,8 @@ function drawDriverSafetyChartForDashboard(ctx, rows, cols, chartType) {
         if(!driverData.length) return;
         const top10=driverData.sort((a,b)=>b.distance-a.distance).slice(0,10);
         console.log('[Driver Safety Dashboard] Creating pie chart with data:', top10);
-        const chart = new Chart(ctx,{ type:'pie', data:{ labels:top10.map(d=>d.driver), datasets:[{ data:top10.map(d=>d.distance), backgroundColor:['#FF6384','#36A2EB','#FFCE56','#4BC0C0','#9966FF','#FF9F40','#FF6B35','#C9CBCF','#4BC0C0','#F7931E'] }] }});
-        console.log('[Driver Safety Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[Driver Safety Dashboard] Chart created');
+        return new Chart(ctx,{ type:'pie', data:{ labels:top10.map(d=>d.driver), datasets:[{ data:top10.map(d=>d.distance), backgroundColor:['#FF6384','#36A2EB','#FFCE56','#4BC0C0','#9966FF','#FF9F40','#FF6B35','#C9CBCF','#4BC0C0','#F7931E'] }] }});
     }
 }
 
@@ -888,16 +874,14 @@ function drawHOSChartForDashboard(ctx, rows, cols, chartType) {
         const palette=['#3366CC','#DC3912','#FF9900','#109618','#990099','#0099C6','#DD4477','#66AA00','#B82E2E','#316395'];
         const datasets=Object.entries(counts).map(([type,byWeek],i)=>({label:type,data:weekLabels.map(w=>byWeek[w]||0),borderColor:palette[i%palette.length],fill:false}));
         console.log('[HOS Dashboard] Creating line chart with data:', counts);
-        const chart = new Chart(ctx,{type:'line',data:{ labels:weekLabels, datasets }});
-        console.log('[HOS Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[HOS Dashboard] Chart created');
+        return new Chart(ctx,{type:'line',data:{ labels:weekLabels, datasets }});
     }else{
         const counts={};
         rows.forEach(r=>{ const val=r[vtIdx]; if(val!==null && val!==undefined && String(val).trim().toLowerCase()!=='null'){ counts[val]=(counts[val]||0)+1; }});
         console.log(`[HOS Dashboard] Creating ${chartType} chart with data:`, counts);
-        const chart = new Chart(ctx,{ type:chartType, data:{ labels:Object.keys(counts), datasets:[{ label:'count', data:Object.values(counts) }] } });
-        console.log('[HOS Dashboard] Chart created:', chart);
-        return chart;
+        console.log('[HOS Dashboard] Chart created');
+        return new Chart(ctx,{ type:chartType, data:{ labels:Object.keys(counts), datasets:[{ label:'count', data:Object.values(counts) }] } });
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure wizard templates loaded from correct path
- configure Chart.js defaults in dashboard
- resize charts after creation and store instances
- return `Chart` instances from dashboard chart functions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68763e564024832caf8182203e0bc12d